### PR TITLE
feat: add basic regression test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,48 +2323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphcast-sdk"
-version = "0.3.2"
-source = "git+https://github.com/graphops/graphcast-sdk#fe2579dc36d87894abc00bde7b7d04bd41e9f08a"
-dependencies = [
- "anyhow",
- "async-graphql",
- "async-graphql-axum",
- "chrono",
- "clap",
- "data-encoding",
- "derive-getters",
- "dotenv",
- "ethers",
- "ethers-contract",
- "ethers-core 2.0.6",
- "ethers-derive-eip712",
- "graphql_client 0.12.0",
- "lazy_static",
- "num-bigint",
- "num-traits",
- "once_cell",
- "partial_application",
- "prometheus-http-query",
- "prost",
- "reqwest",
- "rsb_derive",
- "secp256k1 0.26.0",
- "serde",
- "serde_derive",
- "serde_json",
- "slack-morphism",
- "teloxide",
- "thiserror",
- "tokio",
- "toml 0.7.4",
- "tracing",
- "tracing-subscriber",
- "url",
- "waku-bindings",
-]
-
-[[package]]
 name = "graphql-introspection-query"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,7 +3834,7 @@ dependencies = [
  "ethers-contract",
  "ethers-core 2.0.6",
  "ethers-derive-eip712",
- "graphcast-sdk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graphcast-sdk",
  "graphql_client 0.9.0",
  "hex",
  "metrics",
@@ -5334,7 +5292,7 @@ version = "0.0.1"
 dependencies = [
  "axum 0.5.17",
  "chrono",
- "graphcast-sdk 0.3.2 (git+https://github.com/graphops/graphcast-sdk)",
+ "graphcast-sdk",
  "poi-radio",
  "rand 0.8.5",
  "serde",
@@ -5355,7 +5313,7 @@ version = "0.0.1"
 dependencies = [
  "axum 0.5.17",
  "chrono",
- "graphcast-sdk 0.3.2 (git+https://github.com/graphops/graphcast-sdk)",
+ "graphcast-sdk",
  "poi-radio",
  "rand 0.8.5",
  "ring",
@@ -5373,7 +5331,7 @@ version = "0.0.1"
 dependencies = [
  "axum 0.5.17",
  "chrono",
- "graphcast-sdk 0.3.2 (git+https://github.com/graphops/graphcast-sdk)",
+ "graphcast-sdk",
  "poi-radio",
  "rand 0.8.5",
  "tokio",

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 [dependencies]
 waku = { version = "0.1.0", package = "waku-bindings" }
 test-utils = { path = "../test-utils" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = "0.3.2"
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod message_handling;

--- a/test-runner/src/message_handling.rs
+++ b/test-runner/src/message_handling.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
+use poi_radio::{operator::attestation::Attestation, RadioPayloadMessage};
+use tracing::{debug, info};
+
+pub fn send_and_receive_test(
+    local_attestations: &HashMap<String, HashMap<u64, Attestation>>,
+    remote_messages: &[GraphcastMessage<RadioPayloadMessage>],
+) {
+    debug!("Starting send_and_receive_test");
+
+    assert!(
+        !local_attestations.is_empty(),
+        "There should be at least one element in local_attestations"
+    );
+
+    let test_hashes_local = vec![
+        "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE",
+        "QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE",
+    ];
+
+    for test_hash in test_hashes_local {
+        assert!(
+            local_attestations.contains_key(test_hash),
+            "No attestation found with ipfs hash {}",
+            test_hash
+        );
+    }
+
+    let test_hashes_remote = vec!["QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE"];
+
+    for target_id in test_hashes_remote {
+        let has_target_id = remote_messages
+            .iter()
+            .any(|msg| msg.identifier == *target_id);
+        assert!(
+            has_target_id,
+            "No remote message found with identifier {}",
+            target_id
+        );
+    }
+
+    info!("send_and_receive_test passed ✅");
+}

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.0", package = "waku-bindings" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = "0.3.2"
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-sender/src/main.rs
+++ b/test-sender/src/main.rs
@@ -38,7 +38,7 @@ fn generate_random_poi() -> String {
 pub async fn main() {
     std::env::set_var(
         "RUST_LOG",
-        "off,hyper=off,graphcast_sdk=trace,poi_radio=trace,poi-radio-e2e-tests=trace",
+        "off,hyper=off,graphcast_sdk=info,poi_radio=info,poi-radio-e2e-tests=info",
     );
     init_tracing("pretty".to_string()).expect("Could not set up global default subscriber for logger, check environmental variable `RUST_LOG` or the CLI input `log-level");
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.0", package = "waku-bindings" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = "0.3.2"
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -31,8 +31,7 @@ pub fn test_config(
         waku_addr: None,
         boot_node_addresses: vec![],
         waku_log_level: None,
-        log_level: "off,hyper=off,graphcast_sdk=trace,poi_radio=trace,poi-radio-e2e-tests=trace"
-            .to_string(),
+        log_level: "off,hyper=off,graphcast_sdk=info,poi_radio=info,test_runner=trace".to_string(),
         slack_token: None,
         slack_channel: None,
         discord_webhook: None,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,17 +1,2 @@
 pub mod config;
 pub mod mock_server;
-
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}


### PR DESCRIPTION
### Description

- Remove dummy contents in lib file
- Move basic regression test out from the main `test-runner` file to its own file, which introduces a path for how future tests should be structured
- Use log format from config instead of setting it again in `test-runner.rs`
- Reduce logs from SDK and Radio

### Issue link (if applicable)
Helps with https://github.com/graphops/poi-radio/issues/175
