### PR TITLE
Query objects and resolvers

### DIFF
--- a/poi-radio/src/operator/attestation.rs
+++ b/poi-radio/src/operator/attestation.rs
@@ -491,7 +491,7 @@ pub fn compare_attestations(
 
     let most_attested_npoi = &remote_attestations.last().unwrap().npoi;
     if most_attested_npoi == &local_attestation.npoi {
-        info!(
+        trace!(
             ipfs_hash,
             attestation_block,
             num_unique_npois = remote_attestations.len(),
@@ -505,7 +505,7 @@ pub fn compare_attestations(
             attestations: remote_attestations,
         }
     } else {
-        info!(
+        debug!(
             attestation_block,
             remote_attestations = tracing::field::debug(&remote_attestations),
             local_attestation = tracing::field::debug(&local_attestation),
@@ -532,7 +532,7 @@ pub fn compare_attestation(
 
     let most_attested_npoi = &remote_attestations.last().unwrap().npoi;
     if most_attested_npoi == &local_attestation.npoi {
-        info!(
+        trace!(
             local.block_number,
             remote_attestations = tracing::field::debug(&remote_attestations),
             local_attestation = tracing::field::debug(&local_attestation),
@@ -546,7 +546,7 @@ pub fn compare_attestation(
             attestations: remote_attestations,
         }
     } else {
-        info!(
+        warn!(
             block = local.block_number,
             remote_attestations = tracing::field::debug(&remote_attestations),
             local_attestation = tracing::field::debug(&local_attestation),


### PR DESCRIPTION
### Description

- General performance improvement to resolver functions
- Added local indexer info query resolver, this is used for aggregating attestations. The info is queried everytime the query is made because stake is dynamic but later we can move it to part of radioOperator and do periodic updates to reduce the number of times this query is called.
- New ratio string formatting (local attestation should be included in the aggregation string with "*" to indicate the locally agreed position



### Issue link (if applicable)

Resolves #161 
-> The performance can be dramatically improved by persisting comparisonResults, and can easily add status emoji to the string with comparisonResultTypes

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
