### PR TITLE
refactor: separate tests from main runner file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,48 +2323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphcast-sdk"
-version = "0.3.2"
-source = "git+https://github.com/graphops/graphcast-sdk#fe2579dc36d87894abc00bde7b7d04bd41e9f08a"
-dependencies = [
- "anyhow",
- "async-graphql",
- "async-graphql-axum",
- "chrono",
- "clap",
- "data-encoding",
- "derive-getters",
- "dotenv",
- "ethers",
- "ethers-contract",
- "ethers-core 2.0.6",
- "ethers-derive-eip712",
- "graphql_client 0.12.0",
- "lazy_static",
- "num-bigint",
- "num-traits",
- "once_cell",
- "partial_application",
- "prometheus-http-query",
- "prost",
- "reqwest",
- "rsb_derive",
- "secp256k1 0.26.0",
- "serde",
- "serde_derive",
- "serde_json",
- "slack-morphism",
- "teloxide",
- "thiserror",
- "tokio",
- "toml 0.7.4",
- "tracing",
- "tracing-subscriber",
- "url",
- "waku-bindings",
-]
-
-[[package]]
 name = "graphql-introspection-query"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,7 +3834,7 @@ dependencies = [
  "ethers-contract",
  "ethers-core 2.0.6",
  "ethers-derive-eip712",
- "graphcast-sdk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graphcast-sdk",
  "graphql_client 0.9.0",
  "hex",
  "metrics",
@@ -5334,7 +5292,7 @@ version = "0.0.1"
 dependencies = [
  "axum 0.5.17",
  "chrono",
- "graphcast-sdk 0.3.2 (git+https://github.com/graphops/graphcast-sdk)",
+ "graphcast-sdk",
  "poi-radio",
  "rand 0.8.5",
  "serde",
@@ -5345,7 +5303,6 @@ dependencies = [
  "tower-http 0.4.0",
  "tracing",
  "tracing-subscriber",
- "uuid 1.3.3",
  "waku-bindings",
 ]
 
@@ -5355,10 +5312,15 @@ version = "0.0.1"
 dependencies = [
  "axum 0.5.17",
  "chrono",
- "graphcast-sdk 0.3.2 (git+https://github.com/graphops/graphcast-sdk)",
+ "clap",
+ "graphcast-sdk",
  "poi-radio",
  "rand 0.8.5",
  "ring",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "test-utils",
  "tokio",
  "tower",
  "tower-http 0.4.0",
@@ -5373,7 +5335,7 @@ version = "0.0.1"
 dependencies = [
  "axum 0.5.17",
  "chrono",
- "graphcast-sdk 0.3.2 (git+https://github.com/graphops/graphcast-sdk)",
+ "graphcast-sdk",
  "poi-radio",
  "rand 0.8.5",
  "tokio",
@@ -5381,6 +5343,7 @@ dependencies = [
  "tower-http 0.4.0",
  "tracing",
  "tracing-subscriber",
+ "uuid 1.3.3",
  "waku-bindings",
 ]
 

--- a/poi-radio/src/state.rs
+++ b/poi-radio/src/state.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
 use std::sync::{Arc, Mutex as SyncMutex};
 use std::{
     collections::HashMap,
@@ -105,6 +107,11 @@ impl PersistedState {
         let state_json = serde_json::to_string(&self.clone())
             .unwrap_or_else(|_| "Could not serialize state to JSON".to_owned());
 
+        let path = Path::new(path);
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
         // Write state to file
         let mut file = File::create(path).unwrap();
         file.write_all(state_json.as_bytes()).unwrap();

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 [dependencies]
 waku = { version = "0.1.0", package = "waku-bindings" }
 test-utils = { path = "../test-utils" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = "0.3.2"
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"
@@ -35,4 +35,3 @@ tower-http = { version = "0.4.0", features = ["trace", "cors"] }
 tower = "0.4.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = "1.3.3"

--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod message_handling;
+pub mod topics;

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -1,154 +1,32 @@
-use std::process::{Child, Command};
-use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use graphcast_sdk::init_tracing;
-use poi_radio::config::CoverageLevel;
-use poi_radio::state::PersistedState;
+use test_runner::{message_handling::send_and_receive_test, topics::topics_test};
 use test_utils::config::test_config;
-use test_utils::mock_server::start_mock_server;
-use tokio::time::{sleep, Duration};
-use tracing::{info, trace};
-
-struct Cleanup {
-    sender: Arc<Mutex<Child>>,
-    radio: Arc<Mutex<Child>>,
-}
-
-impl Drop for Cleanup {
-    fn drop(&mut self) {
-        let _ = self.sender.lock().unwrap().kill();
-        let _ = self.radio.lock().unwrap().kill();
-    }
-}
+use tracing::info;
 
 #[tokio::main]
 pub async fn main() {
+    let config = test_config();
+
     std::env::set_var(
         "RUST_LOG",
-        "off,hyper=off,graphcast_sdk=debug,poi_radio=debug,poi-radio-e2e-tests=debug,test_runner=debug,sender=debug,radio=debug",
+        "off,hyper=off,graphcast_sdk=debug,poi_radio=debug,test_runner=debug,test_sender=debug,test_utils=debug",
     );
-    init_tracing("pretty".to_string()).expect("Could not set up global default subscriber for logger, check environmental variable `RUST_LOG` or the CLI input `log-level");
+    init_tracing(config.log_format).expect("Could not set up global default subscriber for logger, check environmental variable `RUST_LOG` or the CLI input `log-level");
 
-    info!("Starting");
+    let start_time = Instant::now();
 
-    let id = uuid::Uuid::new_v4().to_string();
-    std::env::set_var("TEST_RUN_ID", &id);
+    let send_and_receive_task = tokio::spawn(send_and_receive_test());
+    let topics_test_task = tokio::spawn(topics_test());
 
-    let sender = Arc::new(Mutex::new(
-        Command::new("cargo")
-            .arg("run")
-            .arg("-p")
-            .arg("test-sender")
-            .spawn()
-            .expect("Failed to start command"),
-    ));
+    let (_send_and_receive_result, _topics_test_result) =
+        tokio::join!(send_and_receive_task, topics_test_task);
 
-    let host = "127.0.0.1:8085";
-    tokio::spawn(start_mock_server(host));
+    let elapsed_time = start_time.elapsed();
 
-    let config = test_config(
-        format!("http://{}/graphql", host),
-        format!("http://{}/registry-subgraph", host),
-        format!("http://{}/network-subgraph", host),
+    info!(
+        "All checks passed ✅. Time elapsed: {}s",
+        elapsed_time.as_secs()
     );
-
-    let radio = Arc::new(Mutex::new(
-        Command::new("cargo")
-            .arg("run")
-            .arg("-p")
-            .arg("poi-radio")
-            .arg("--")
-            .arg("--graph-node-endpoint")
-            .arg(&config.graph_node_endpoint)
-            .arg("--private-key")
-            .arg(config.private_key.as_deref().unwrap_or("None"))
-            .arg("--registry-subgraph")
-            .arg(&config.registry_subgraph)
-            .arg("--network-subgraph")
-            .arg(&config.network_subgraph)
-            .arg("--graphcast-network")
-            .arg(&config.graphcast_network)
-            .arg("--topics")
-            .arg(config.topics.join(","))
-            .arg("--coverage")
-            .arg(match config.coverage {
-                CoverageLevel::Minimal => "minimal",
-                CoverageLevel::OnChain => "on-chain",
-                CoverageLevel::Comprehensive => "comprehensive",
-            })
-            .arg("--collect-message-duration")
-            .arg(config.collect_message_duration.to_string())
-            .arg("--waku-log-level")
-            .arg(config.waku_log_level.as_deref().unwrap_or("None"))
-            .arg("--log-level")
-            .arg(&config.log_level)
-            .arg("--slack-token")
-            .arg(config.slack_token.as_deref().unwrap_or("None"))
-            .arg("--slack-channel")
-            .arg(config.slack_channel.as_deref().unwrap_or("None"))
-            .arg("--discord-webhook")
-            .arg(config.discord_webhook.as_deref().unwrap_or("None"))
-            .arg("--persistence-file-path")
-            .arg(config.persistence_file_path.as_deref().unwrap_or("None"))
-            .arg("--log-format")
-            .arg(&config.log_format)
-            .arg("--radio-name")
-            .arg(&config.radio_name)
-            .spawn()
-            .expect("Failed to start command"),
-    ));
-
-    let cleanup = Cleanup {
-        sender: Arc::clone(&sender),
-        radio: Arc::clone(&radio),
-    };
-
-    // Wait for 3 minutes asynchronously
-    sleep(Duration::from_secs(180)).await;
-
-    // Kill the processes
-    let _ = cleanup.sender.lock().unwrap().kill();
-    let _ = cleanup.radio.lock().unwrap().kill();
-
-    // Read the content of the state.json file
-    let state_file_path = "./test-runner/state.json";
-    let persisted_state = PersistedState::load_cache(state_file_path);
-    trace!("persisted state {:?}", persisted_state);
-
-    let local_attestations = persisted_state.local_attestations();
-
-    assert!(
-        !local_attestations.is_empty(),
-        "There should be at least one element in local_attestations"
-    );
-
-    let test_hashes_local = vec![
-        "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE",
-        "QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE",
-    ];
-
-    for test_hash in test_hashes_local {
-        assert!(
-            local_attestations.contains_key(test_hash),
-            "No attestation found with ipfs hash {}",
-            test_hash
-        );
-    }
-
-    let remote_messages = persisted_state.remote_messages();
-
-    let test_hashes_remote = vec!["QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE"];
-
-    for target_id in test_hashes_remote {
-        let has_target_id = remote_messages
-            .iter()
-            .any(|msg| msg.identifier == *target_id);
-        assert!(
-            has_target_id,
-            "No remote message found with identifier {}",
-            target_id
-        );
-    }
-
-    info!("All checks passed ✅");
 }

--- a/test-runner/src/message_handling.rs
+++ b/test-runner/src/message_handling.rs
@@ -1,0 +1,60 @@
+use poi_radio::state::PersistedState;
+use test_utils::{config::test_config, setup, teardown};
+use tokio::time::{sleep, Duration};
+use tracing::{debug, info};
+
+pub async fn send_and_receive_test() {
+    let test_file_name = "message_handling";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    let process_manager = setup(&config, test_file_name);
+
+    // Wait for 3 minutes asynchronously
+    sleep(Duration::from_secs(180)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    // Calling teardown ealy since we don't need the processes to run after getting a snapshot of the state
+    teardown(process_manager, &store_path);
+
+    let local_attestations = persisted_state.local_attestations();
+    let remote_messages = persisted_state.remote_messages();
+
+    debug!("Starting send_and_receive_test");
+
+    assert!(
+        !local_attestations.is_empty(),
+        "There should be at least one element in local_attestations"
+    );
+
+    let test_hashes_local = vec![
+        "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE",
+        "QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE",
+    ];
+
+    for test_hash in test_hashes_local {
+        assert!(
+            local_attestations.contains_key(test_hash),
+            "No attestation found with ipfs hash {}",
+            test_hash
+        );
+    }
+
+    let test_hashes_remote = vec!["QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE"];
+
+    for target_id in test_hashes_remote {
+        let has_target_id = remote_messages
+            .iter()
+            .any(|msg| msg.identifier == *target_id);
+        assert!(
+            has_target_id,
+            "No remote message found with identifier {}",
+            target_id
+        );
+    }
+
+    info!("send_and_receive_test passed ✅");
+}

--- a/test-runner/src/topics.rs
+++ b/test-runner/src/topics.rs
@@ -1,0 +1,60 @@
+use poi_radio::state::PersistedState;
+use test_utils::{config::test_config, setup, teardown};
+use tokio::time::{sleep, Duration};
+use tracing::{debug, info};
+
+pub async fn topics_test() {
+    let test_file_name = "topics";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    let process_manager = setup(&config, test_file_name);
+
+    // Wait for 3 minutes asynchronously
+    sleep(Duration::from_secs(180)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    // Calling teardown ealy since we don't need the processes to run after getting a snapshot of the state
+    teardown(process_manager, &store_path);
+
+    let local_attestations = persisted_state.local_attestations();
+    let remote_messages = persisted_state.remote_messages();
+
+    debug!("Starting topics_test");
+
+    assert!(
+        !local_attestations.is_empty(),
+        "There should be at least one element in local_attestations"
+    );
+
+    let test_hashes_local = vec![
+        "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE",
+        "QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE",
+    ];
+
+    for test_hash in test_hashes_local {
+        assert!(
+            local_attestations.contains_key(test_hash),
+            "No attestation found with ipfs hash {}",
+            test_hash
+        );
+    }
+
+    let test_hashes_remote = vec!["QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE"];
+
+    for target_id in test_hashes_remote {
+        let has_target_id = remote_messages
+            .iter()
+            .any(|msg| msg.identifier == *target_id);
+        assert!(
+            has_target_id,
+            "No remote message found with identifier {}",
+            target_id
+        );
+    }
+
+    info!("topics_test passed ✅");
+}

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -22,7 +22,8 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.0", package = "waku-bindings" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+test-utils = { path = "../test-utils" }
+graphcast-sdk = "0.3.2"
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"
@@ -33,3 +34,7 @@ axum = "0.5"
 tower-http = { version = "0.4.0", features = ["trace", "cors"] }
 tower = "0.4.13"
 ring = "0.16.19"
+serde = { version = "1.0.163", features = ["rc"] }
+serde_json = "1.0.96"
+serde_derive = "1.0"
+clap = { version = "3.2.25", features = ["derive"] }

--- a/test-sender/src/config.rs
+++ b/test-sender/src/config.rs
@@ -1,0 +1,11 @@
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Parser, Serialize, Deserialize)]
+#[clap(name = "test-sender", about = "Mock message sender")]
+pub struct SenderConfig {
+    #[clap(long, value_name = "TOPICS", help = "Topics for test messages")]
+    pub topics: Vec<String>,
+    #[clap(long, value_name = "RADIO_NAME", help = "Instance-specific radio name")]
+    pub radio_name: String,
+}

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.0", package = "waku-bindings" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = "0.3.2"
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"
@@ -32,3 +32,4 @@ chrono = "0.4"
 axum = "0.5"
 tower-http = { version = "0.4.0", features = ["trace", "cors"] }
 tower = "0.4.13"
+uuid = "1.3.3"

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -1,23 +1,14 @@
-use std::env;
-
 use poi_radio::config::{Config, CoverageLevel};
 
-pub fn test_config(
-    graph_node_endpoint: String,
-    registry_subgraph: String,
-    network_subgraph: String,
-) -> Config {
-    let id = env::var("TEST_RUN_ID").unwrap_or_else(|_| panic!("TEST_RUN_ID not set"));
-    let radio_name = format!("poi-radio-test-{}", id);
-
+pub fn test_config() -> Config {
     Config {
-        graph_node_endpoint,
+        graph_node_endpoint: String::new(),
         private_key: Some(
             "ccaea3e3aca412cb3920dbecd77bc725dfe9a5e16f940f19912d9c9dbee01e8f".to_string(),
         ),
         mnemonic: None,
-        registry_subgraph,
-        network_subgraph,
+        registry_subgraph: String::new(),
+        network_subgraph: String::new(),
         graphcast_network: "testnet".to_string(),
         topics: vec![
             "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE".to_string(),
@@ -31,8 +22,7 @@ pub fn test_config(
         waku_addr: None,
         boot_node_addresses: vec![],
         waku_log_level: None,
-        log_level: "off,hyper=off,graphcast_sdk=trace,poi_radio=trace,poi-radio-e2e-tests=trace"
-            .to_string(),
+        log_level: "off,hyper=off,graphcast_sdk=info,poi_radio=info,test_runner=trace".to_string(),
         slack_token: None,
         slack_channel: None,
         discord_webhook: None,
@@ -40,9 +30,9 @@ pub fn test_config(
         metrics_port: None,
         server_host: String::new(),
         server_port: None,
-        persistence_file_path: Some("./test-runner/state.json".to_string()),
+        persistence_file_path: None,
         log_format: "pretty".to_string(),
-        radio_name,
+        radio_name: String::new(),
         telegram_chat_id: None,
         telegram_token: None,
         discv5_enrs: None,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,17 +1,199 @@
+use std::{
+    fs,
+    net::{TcpListener, UdpSocket},
+    path::Path,
+    process::{Child, Command},
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
+};
+
+use mock_server::start_mock_server;
+use poi_radio::config::{Config, CoverageLevel};
+use rand::Rng;
+use tracing::info;
+
 pub mod config;
 pub mod mock_server;
 
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+pub struct ProcessManager {
+    pub senders: Vec<Arc<Mutex<Child>>>,
+    pub radio: Arc<Mutex<Child>>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl Drop for ProcessManager {
+    fn drop(&mut self) {
+        let _ = self.senders.get(0).unwrap().lock().unwrap().kill();
+        let _ = self.radio.lock().unwrap().kill();
     }
+}
+
+fn find_random_tcp_port() -> u16 {
+    let mut rng = rand::thread_rng();
+    let mut port = 0;
+
+    for _ in 0..10 {
+        // Generate a random port number within the range 49152 to 65535
+        let test_port = rng.gen_range(49152..=65535);
+        match TcpListener::bind(("0.0.0.0", test_port)) {
+            Ok(_) => {
+                port = test_port;
+                break;
+            }
+            Err(_) => {
+                println!("Port {} is not available, retrying...", test_port);
+                thread::sleep(Duration::from_secs(1));
+                continue;
+            }
+        }
+    }
+
+    if port == 0 {
+        panic!("Could not find a free port");
+    }
+
+    port
+}
+
+pub fn setup(config: &Config, test_file_name: &str) -> ProcessManager {
+    assert!(
+        !Path::new(&config.persistence_file_path.clone().unwrap()).exists(),
+        "State file already exists, previous test may have not cleaned up successfully"
+    );
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let radio_name = format!("{}-{}", test_file_name, id);
+
+    // TODO: Make sender accept custom config
+    let basic_sender = Arc::new(Mutex::new(
+        Command::new("cargo")
+            .arg("run")
+            .arg("-p")
+            .arg("test-sender")
+            .arg("--")
+            .arg("--topics")
+            .arg("QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE")
+            .arg("--radio-name")
+            .arg(&radio_name)
+            .spawn()
+            .expect("Failed to start command"),
+    ));
+
+    let port = find_random_tcp_port();
+
+    let host = format!("127.0.0.1:{}", port);
+    tokio::spawn(start_mock_server(host.clone()));
+
+    let waku_port = find_random_udp_port();
+    let discv5_port = find_random_udp_port();
+
+    let mut config = config.clone();
+    config.graph_node_endpoint = format!("http://{}/graphql", host);
+    config.registry_subgraph = format!("http://{}/registry-subgraph", host);
+    config.network_subgraph = format!("http://{}/network-subgraph", host);
+    config.radio_name = radio_name;
+    config.waku_port = Some(waku_port.to_string());
+    config.discv5_port = Some(discv5_port);
+
+    info!(
+        "Starting POI Radio instance on port {}",
+        waku_port.to_string()
+    );
+
+    let radio = Arc::new(Mutex::new(start_radio(&config)));
+
+    ProcessManager {
+        senders: vec![Arc::clone(&basic_sender)],
+        radio: Arc::clone(&radio),
+    }
+}
+
+pub fn teardown(process_manager: ProcessManager, store_path: &str) {
+    // Kill the processes
+    for sender in &process_manager.senders {
+        let _ = sender.lock().unwrap().kill();
+    }
+    let _ = process_manager.radio.lock().unwrap().kill();
+
+    if Path::new(&store_path).exists() {
+        fs::remove_file(store_path).unwrap();
+    }
+}
+
+pub fn start_radio(config: &Config) -> Child {
+    Command::new("cargo")
+        .arg("run")
+        .arg("-p")
+        .arg("poi-radio")
+        .arg("--")
+        .arg("--graph-node-endpoint")
+        .arg(&config.graph_node_endpoint)
+        .arg("--private-key")
+        .arg(config.private_key.as_deref().unwrap_or("None"))
+        .arg("--registry-subgraph")
+        .arg(&config.registry_subgraph)
+        .arg("--network-subgraph")
+        .arg(&config.network_subgraph)
+        .arg("--graphcast-network")
+        .arg(&config.graphcast_network)
+        .arg("--topics")
+        .arg(config.topics.join(","))
+        .arg("--coverage")
+        .arg(match config.coverage {
+            CoverageLevel::Minimal => "minimal",
+            CoverageLevel::OnChain => "on-chain",
+            CoverageLevel::Comprehensive => "comprehensive",
+        })
+        .arg("--collect-message-duration")
+        .arg(config.collect_message_duration.to_string())
+        .arg("--waku-log-level")
+        .arg(config.waku_log_level.as_deref().unwrap_or("None"))
+        .arg("--waku-port")
+        .arg(config.waku_port.as_deref().unwrap_or("None"))
+        .arg("--log-level")
+        .arg(&config.log_level)
+        .arg("--slack-token")
+        .arg(config.slack_token.as_deref().unwrap_or("None"))
+        .arg("--slack-channel")
+        .arg(config.slack_channel.as_deref().unwrap_or("None"))
+        .arg("--discord-webhook")
+        .arg(config.discord_webhook.as_deref().unwrap_or("None"))
+        .arg("--persistence-file-path")
+        .arg(config.persistence_file_path.as_deref().unwrap_or("None"))
+        .arg("--log-format")
+        .arg(&config.log_format)
+        .arg("--radio-name")
+        .arg(&config.radio_name)
+        .arg("--discv5-port")
+        .arg(
+            config
+                .discv5_port
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "None".to_string()),
+        )
+        .spawn()
+        .expect("Failed to start command")
+}
+
+pub fn find_random_udp_port() -> u16 {
+    let mut rng = rand::thread_rng();
+    let mut port = 0;
+
+    for _ in 0..10 {
+        // Generate a random port number within the range 49152 to 65535
+        let test_port = rng.gen_range(49152..=65535);
+        match UdpSocket::bind(("0.0.0.0", test_port)) {
+            Ok(_) => {
+                port = test_port;
+                break;
+            }
+            Err(_) => continue,
+        }
+    }
+
+    if port == 0 {
+        panic!("Could not find a free port");
+    }
+
+    port
 }

--- a/test-utils/src/mock_server.rs
+++ b/test-utils/src/mock_server.rs
@@ -6,7 +6,7 @@ use std::{convert::Infallible, net::SocketAddr, str::FromStr};
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
-pub async fn start_mock_server(address: &str) {
+pub async fn start_mock_server(address: String) {
     // Define the HTTP handlers
     let app = Router::new()
         .route("/graphql", post(handler_graphql))
@@ -19,7 +19,7 @@ pub async fn start_mock_server(address: &str) {
         );
 
     // Create the server and start listening for requests
-    let addr = SocketAddr::from_str(address).unwrap();
+    let addr = SocketAddr::from_str(&address).unwrap();
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await


### PR DESCRIPTION
Separates the tests from the main runner file, makes every test self-defined and self-contained. This PR started off as an improvement over https://github.com/graphops/poi-radio/pull/184 based on @hopeyen 's suggestions 🚀 , then further improvements were made:

1. Tests are ran in parallel now, and the full test suite should never take more than 3 minutes.
2. ...