### PR TITLE
feat: add msg sender validation options

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -28,6 +28,6 @@ changelog:
     - title: Refactor 🌱
       labels:
         - refactor
-    - title: Other Changes
+    - title: Other Changes 🗳️
       labels:
         - "*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,8 +2288,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f280b49f7aa775a9b193ff35ae9d3063f4db2156b9c1160f8610d3a385ffb593"
+source = "git+https://github.com/graphops/graphcast-sdk#a52bb1b6ce4f145f08bbf0b67b735f6645b24e1e"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/poi-radio/Cargo.toml
+++ b/poi-radio/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories = ["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = "0.3.4"
+graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 prost = "0.11"
 once_cell = "1.17"
 chrono = "0.4"

--- a/poi-radio/benches/gossips.rs
+++ b/poi-radio/benches/gossips.rs
@@ -1,5 +1,6 @@
 use criterion::async_executor::FuturesExecutor;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
 use poi_radio::operator::RadioOperator;
 
 use rand::{thread_rng, Rng};
@@ -20,6 +21,7 @@ fn gossip_poi_bench(c: &mut Criterion) {
 
     let config = black_box(Config {
         radio_name: String::from("test"),
+        indexer_address: String::from("indexer_address"),
         graph_node_endpoint: String::from("http://localhost:8030/graphql"),
         private_key: Some(pk.display_secret().to_string()),
         mnemonic: None,
@@ -54,6 +56,7 @@ fn gossip_poi_bench(c: &mut Criterion) {
         discv5_enrs: None,
         discv5_port: None,
         filter_protocol: None,
+        id_validation: Some(IdentityValidation::NoCheck),
     });
 
     c.bench_function("gossip_poi", move |b| {

--- a/poi-radio/src/operator/operation.rs
+++ b/poi-radio/src/operator/operation.rs
@@ -181,7 +181,6 @@ pub async fn message_send(
 pub async fn message_comparison(
     id: String,
     collect_window_duration: i64,
-    registry_subgraph: String,
     network_subgraph: String,
     messages: Vec<GraphcastMessage<RadioPayloadMessage>>,
     local_attestations: HashMap<String, HashMap<u64, Attestation>>,
@@ -228,8 +227,7 @@ pub async fn message_comparison(
         number_of_messages_matched_to_compare = filter_msg.len(),
         "Comparison state",
     );
-    let remote_attestations_result =
-        process_messages(filter_msg, &registry_subgraph, &network_subgraph).await;
+    let remote_attestations_result = process_messages(filter_msg, &network_subgraph).await;
     let remote_attestations = match remote_attestations_result {
         Ok(remote) => {
             debug!(unique_remote_nPOIs = remote.len(), "Processed messages",);
@@ -419,7 +417,6 @@ impl RadioOperator {
             /* Set up */
             let collect_duration: i64 = self.config.collect_message_duration().to_owned();
             let id_cloned = id.clone();
-            let registry_subgraph = self.config.registry_subgraph.clone();
             let network_subgraph = self.config.network_subgraph.clone();
             let local_attestations = self.state().local_attestations();
             let filtered_msg = remote_messages
@@ -432,7 +429,6 @@ impl RadioOperator {
                 message_comparison(
                     id_cloned,
                     collect_duration,
-                    registry_subgraph.clone(),
                     network_subgraph.clone(),
                     filtered_msg,
                     local_attestations,

--- a/poi-radio/src/state.rs
+++ b/poi-radio/src/state.rs
@@ -211,6 +211,7 @@ mod tests {
             NetworkName::Goerli,
             block_number,
             block_hash,
+            String::from("0xe9a1cabd57700b17945fd81feefba82340d9568f"),
             sig,
         )
         .expect("Shouldn't get here since the message is purposefully constructed for testing");

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
 test-utils = { path = "../test-utils" }
-graphcast-sdk = "0.3.4"
+graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -1,6 +1,7 @@
 use std::process::{Child, Command};
 use std::sync::{Arc, Mutex};
 
+use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
 use graphcast_sdk::init_tracing;
 use poi_radio::config::CoverageLevel;
 use poi_radio::state::PersistedState;
@@ -64,6 +65,8 @@ pub async fn main() {
             .arg(config.private_key.as_deref().unwrap_or("None"))
             .arg("--registry-subgraph")
             .arg(&config.registry_subgraph)
+            .arg("--indexer-address")
+            .arg(&config.indexer_address)
             .arg("--network-subgraph")
             .arg(&config.network_subgraph)
             .arg("--graphcast-network")
@@ -94,6 +97,15 @@ pub async fn main() {
             .arg(&config.log_format)
             .arg("--radio-name")
             .arg(&config.radio_name)
+            .arg("--id-validation")
+            .arg(match config.id_validation {
+                Some(IdentityValidation::NoCheck) => "no-check",
+                Some(IdentityValidation::ValidAddress) => "valid-address",
+                Some(IdentityValidation::GraphNetworkAccount) => "graph-network-account",
+                Some(IdentityValidation::GraphcastRegistered) => "graphcast-registered",
+                Some(IdentityValidation::Indexer) => "indexer",
+                _ => "registered-indexer",
+            })
             .spawn()
             .expect("Failed to start command"),
     ));

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = "0.3.4"
+graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-sender/src/main.rs
+++ b/test-sender/src/main.rs
@@ -98,6 +98,7 @@ pub async fn main() {
             NetworkName::Goerli,
             timestamp.try_into().unwrap(),
             "4dbba1ba9fb18b0034965712598be1368edcf91ae2c551d59462aab578dab9c5".to_string(),
+            "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
         )
         .await
         .unwrap();

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = "0.3.4"
+graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
 use poi_radio::config::{Config, CoverageLevel};
 
 pub fn test_config(
@@ -12,6 +13,7 @@ pub fn test_config(
 
     Config {
         graph_node_endpoint,
+        indexer_address: String::from("0x7e6528e4ce3055e829a32b5dc4450072bac28bc6"),
         private_key: Some(
             "ccaea3e3aca412cb3920dbecd77bc725dfe9a5e16f940f19912d9c9dbee01e8f".to_string(),
         ),
@@ -48,5 +50,6 @@ pub fn test_config(
         discv5_enrs: None,
         discv5_port: None,
         filter_protocol: None,
+        id_validation: Some(IdentityValidation::ValidAddress),
     }
 }


### PR DESCRIPTION
### Description

- Add config options
- Utilize verifications for `graph_account` during `check_message_validity` and remove the duplicate validation during comparison

### Issue link (if applicable)

Merge after https://github.com/graphops/graphcast-sdk/issues/204

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
