### PR TITLE
feat: move e2e tests into separate files and add new scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
  "fnv",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "mime",
  "multer",
  "num-traits",
@@ -260,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a941b499fead4a3fb5392cabf42446566d18c86313f69f2deab69560394d65f"
 dependencies = [
  "bytes",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_json",
 ]
@@ -273,7 +273,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -588,9 +588,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -831,7 +831,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -1245,7 +1245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1543,6 +1543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
 name = "erasable"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,8 +1715,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.18",
- "toml 0.7.4",
+ "syn 2.0.22",
+ "toml 0.7.5",
  "walkdir",
 ]
 
@@ -1727,7 +1733,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1784,7 +1790,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.18",
+ "syn 2.0.22",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2164,7 +2170,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2288,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.3.4"
-source = "git+https://github.com/graphops/graphcast-sdk#a52bb1b6ce4f145f08bbf0b67b735f6645b24e1e"
+source = "git+https://github.com/graphops/graphcast-sdk#caf69d0e50608dd8da843a677c9e975802462284"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2320,7 +2326,7 @@ dependencies = [
  "teloxide",
  "thiserror",
  "tokio",
- "toml 0.7.4",
+ "toml 0.7.5",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2470,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -2480,7 +2486,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -2501,6 +2507,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hashers"
@@ -2662,9 +2674,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2802,8 +2814,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -2843,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
@@ -2979,9 +3001,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -3087,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
 dependencies = [
  "hyper",
- "indexmap",
+ "indexmap 1.9.3",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -3118,7 +3140,7 @@ checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.12.3",
  "metrics",
  "num_cpus",
  "parking_lot",
@@ -3371,7 +3393,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3449,7 +3471,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3500,7 +3522,7 @@ dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3655,9 +3677,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3670,7 +3692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -3685,35 +3707,35 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.1",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
- "phf_shared 0.11.1",
+ "phf_shared 0.11.2",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.1",
+ "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3727,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -3751,7 +3773,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3914,7 +3936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3967,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -4436,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
@@ -4718,14 +4740,14 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -4754,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
@@ -5076,7 +5098,7 @@ dependencies = [
  "quote",
  "regex-syntax 0.6.29",
  "strsim",
- "syn 2.0.18",
+ "syn 2.0.22",
  "unicode-width",
 ]
 
@@ -5166,9 +5188,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5264,7 +5286,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
- "uuid 1.3.4",
+ "uuid 1.4.0",
 ]
 
 [[package]]
@@ -5318,7 +5340,6 @@ dependencies = [
  "tower-http 0.4.1",
  "tracing",
  "tracing-subscriber",
- "uuid 1.3.4",
  "waku-bindings",
 ]
 
@@ -5328,10 +5349,17 @@ version = "0.0.1"
 dependencies = [
  "axum 0.5.17",
  "chrono",
+ "clap",
+ "ethers",
  "graphcast-sdk",
  "poi-radio",
+ "prost",
  "rand 0.8.5",
  "ring",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "test-utils",
  "tokio",
  "tower",
  "tower-http 0.4.1",
@@ -5344,16 +5372,27 @@ dependencies = [
 name = "test-utils"
 version = "0.0.1"
 dependencies = [
+ "async-graphql",
  "axum 0.5.17",
  "chrono",
+ "clap",
+ "ethers",
+ "ethers-contract",
+ "ethers-core 2.0.7",
+ "ethers-derive-eip712",
  "graphcast-sdk",
  "poi-radio",
+ "prost",
  "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "tokio",
  "tower",
  "tower-http 0.4.1",
  "tracing",
  "tracing-subscriber",
+ "uuid 1.4.0",
  "waku-bindings",
 ]
 
@@ -5380,7 +5419,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5465,11 +5504,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -5491,7 +5531,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5579,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -5591,20 +5631,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5652,7 +5692,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.3.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5692,13 +5732,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5956,9 +5996,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 dependencies = [
  "getrandom 0.2.10",
 ]
@@ -6082,7 +6122,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
@@ -6116,7 +6156,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6255,9 +6295,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/poi-radio/benches/gossips.rs
+++ b/poi-radio/benches/gossips.rs
@@ -57,6 +57,7 @@ fn gossip_poi_bench(c: &mut Criterion) {
         discv5_port: None,
         filter_protocol: None,
         id_validation: Some(IdentityValidation::NoCheck),
+        topic_update_interval: 600,
     });
 
     c.bench_function("gossip_poi", move |b| {

--- a/poi-radio/src/config.rs
+++ b/poi-radio/src/config.rs
@@ -295,6 +295,13 @@ pub struct Config {
         indexer: must be registered at Graphcast Registry or is a Graph Account, correspond to and Indexer statisfying indexer minimum stake requirement"
     )]
     pub id_validation: Option<IdentityValidation>,
+    #[clap(
+        long,
+        value_name = "TOPIC_UPDATE_INTERVAL",
+        env = "TOPIC_UPDATE_INTERVAL",
+        default_value = "600"
+    )]
+    pub topic_update_interval: u64,
 }
 
 impl Config {

--- a/poi-radio/src/operator/mod.rs
+++ b/poi-radio/src/operator/mod.rs
@@ -190,7 +190,9 @@ impl RadioOperator {
         let skip_iteration = Arc::new(AtomicBool::new(false));
         let skip_iteration_clone = skip_iteration.clone();
 
-        let mut topic_update_interval = interval(Duration::from_secs(600));
+        let mut topic_update_interval =
+            interval(Duration::from_secs(self.config.topic_update_interval));
+
         let mut state_update_interval = interval(Duration::from_secs(60));
         let mut gossip_poi_interval = interval(Duration::from_secs(30));
         let mut comparison_interval = interval(Duration::from_secs(30));

--- a/poi-radio/src/state.rs
+++ b/poi-radio/src/state.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
 use std::sync::{Arc, Mutex as SyncMutex};
 use std::{
     collections::HashMap,
@@ -105,6 +107,11 @@ impl PersistedState {
         let state_json = serde_json::to_string(&self.clone())
             .unwrap_or_else(|_| "Could not serialize state to JSON".to_owned());
 
+        let path = Path::new(path);
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
         // Write state to file
         let mut file = File::create(path).unwrap();
         file.write_all(state_json.as_bytes()).unwrap();

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -35,4 +35,3 @@ tower-http = { version = "0.4.0", features = ["trace", "cors"] }
 tower = "0.4.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = "1.3.3"

--- a/test-runner/src/invalid_block_hash.rs
+++ b/test-runner/src/invalid_block_hash.rs
@@ -1,0 +1,47 @@
+use poi_radio::state::PersistedState;
+use test_utils::{
+    config::{test_config, TestSenderConfig},
+    setup, teardown,
+};
+use tokio::time::{sleep, Duration};
+use tracing::debug;
+
+pub async fn invalid_block_hash_test() {
+    let test_file_name = "invalid_block_hash";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let radio_topics = vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let test_sender_topics =
+        vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    config.topics = radio_topics.clone();
+
+    let mut test_sender_config = TestSenderConfig {
+        topics: test_sender_topics,
+        radio_name: String::new(),
+        block_hash: Some(
+            "3071f4b00c2fc57c7f97d18e77b0e9c377cebae15959e6254b1a1d48a83b92e8".to_string(),
+        ),
+        staked_tokens: None,
+        nonce: None,
+        radio_payload: None,
+    };
+
+    let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
+
+    sleep(Duration::from_secs(89)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    teardown(process_manager, &store_path);
+
+    let remote_messages = persisted_state.remote_messages();
+    assert!(
+        remote_messages.is_empty(),
+        "Remote messages should be empty"
+    );
+}

--- a/test-runner/src/invalid_nonce.rs
+++ b/test-runner/src/invalid_nonce.rs
@@ -1,0 +1,45 @@
+use poi_radio::state::PersistedState;
+use test_utils::{
+    config::{test_config, TestSenderConfig},
+    setup, teardown,
+};
+use tokio::time::{sleep, Duration};
+use tracing::debug;
+
+pub async fn invalid_nonce_test() {
+    let test_file_name = "invalid_nonce";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let radio_topics = vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let test_sender_topics =
+        vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    config.topics = radio_topics.clone();
+
+    let mut test_sender_config = TestSenderConfig {
+        topics: test_sender_topics,
+        radio_name: String::new(),
+        block_hash: None,
+        staked_tokens: None,
+        nonce: Some("1655850000".to_string()),
+        radio_payload: None,
+    };
+
+    let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
+
+    sleep(Duration::from_secs(89)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    teardown(process_manager, &store_path);
+
+    let remote_messages = persisted_state.remote_messages();
+    assert!(
+        remote_messages.is_empty(),
+        "Remote messages should be empty"
+    );
+}

--- a/test-runner/src/invalid_payload.rs
+++ b/test-runner/src/invalid_payload.rs
@@ -1,0 +1,50 @@
+use poi_radio::state::PersistedState;
+use test_utils::{
+    config::{test_config, TestSenderConfig},
+    dummy_msg::DummyMsg,
+    setup, teardown,
+};
+use tokio::time::{sleep, Duration};
+use tracing::debug;
+
+pub async fn invalid_payload_test() {
+    let test_file_name = "invalid_payload";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let radio_topics = vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let test_sender_topics =
+        vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    config.topics = radio_topics.clone();
+
+    let dummy_radio_payload = DummyMsg::new("hello".to_string(), 42);
+
+    let mut test_sender_config = TestSenderConfig {
+        topics: test_sender_topics,
+        radio_name: String::new(),
+        block_hash: Some(
+            "3071f4b00c2fc57c7f97d18e77b0e9c377cebae15959e6254b1a1d48a83b92e8".to_string(),
+        ),
+        staked_tokens: None,
+        nonce: None,
+        radio_payload: Some(DummyMsg::to_json(&dummy_radio_payload)),
+    };
+
+    let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
+
+    sleep(Duration::from_secs(89)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    teardown(process_manager, &store_path);
+
+    let remote_messages = persisted_state.remote_messages();
+    assert!(
+        remote_messages.is_empty(),
+        "Remote messages should be empty"
+    );
+}

--- a/test-runner/src/invalid_sender.rs
+++ b/test-runner/src/invalid_sender.rs
@@ -1,0 +1,47 @@
+use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
+use poi_radio::state::PersistedState;
+use test_utils::{
+    config::{test_config, TestSenderConfig},
+    setup, teardown,
+};
+use tokio::time::{sleep, Duration};
+use tracing::debug;
+
+pub async fn invalid_sender_test() {
+    let test_file_name = "invalid_sender";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let radio_topics = vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let test_sender_topics =
+        vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    config.topics = radio_topics.clone();
+    config.id_validation = Some(IdentityValidation::RegisteredIndexer);
+
+    let mut test_sender_config = TestSenderConfig {
+        topics: test_sender_topics,
+        radio_name: String::new(),
+        block_hash: None,
+        staked_tokens: Some("1".to_string()),
+        nonce: None,
+        radio_payload: None,
+    };
+
+    let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
+
+    sleep(Duration::from_secs(89)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    teardown(process_manager, &store_path);
+
+    let remote_messages = persisted_state.remote_messages();
+    assert!(
+        remote_messages.is_empty(),
+        "Remote messages should be empty"
+    );
+}

--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod invalid_block_hash;
+pub mod invalid_nonce;
+pub mod invalid_payload;
+pub mod invalid_sender;
+pub mod message_handling;
+pub mod topics;

--- a/test-runner/src/message_handling.rs
+++ b/test-runner/src/message_handling.rs
@@ -1,0 +1,93 @@
+use poi_radio::state::PersistedState;
+use test_utils::{
+    config::{test_config, TestSenderConfig},
+    setup, teardown,
+};
+use tokio::time::{sleep, Duration};
+use tracing::{debug, trace};
+
+pub async fn send_and_receive_test() {
+    let test_file_name = "message_handling";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let radio_topics = vec![
+        "Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string(),
+        "Qmdefault2XyZABCdefGHIjklMNOpqrstuvWXYZabcdefGHIJKLMN".to_string(),
+    ];
+
+    let test_sender_topics =
+        vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    config.topics = radio_topics.clone();
+
+    let mut test_sender_config = TestSenderConfig {
+        topics: test_sender_topics,
+        radio_name: String::new(),
+        block_hash: None,
+        staked_tokens: None,
+        nonce: None,
+        radio_payload: None,
+    };
+
+    let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
+
+    sleep(Duration::from_secs(89)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    teardown(process_manager, &store_path);
+
+    let local_attestations = persisted_state.local_attestations();
+    let remote_messages = persisted_state.remote_messages();
+
+    debug!("Starting send_and_receive_test");
+
+    assert!(
+        !local_attestations.is_empty(),
+        "There should be at least one element in local_attestations"
+    );
+
+    for test_hash in radio_topics {
+        assert!(
+            local_attestations.contains_key(&test_hash),
+            "No attestation found with ipfs hash {}",
+            test_hash
+        );
+    }
+
+    let test_hashes_remote = vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq"];
+
+    for target_id in test_hashes_remote {
+        let has_target_id = remote_messages
+            .iter()
+            .any(|msg| msg.identifier == *target_id);
+        assert!(
+            has_target_id,
+            "No remote message found with identifier {}",
+            target_id
+        );
+    }
+
+    trace!("Num of remote messages {}", remote_messages.len());
+
+    assert!(
+        remote_messages.len() >= 10,
+        "The number of remote messages should at least 10. Actual: {}",
+        remote_messages.len()
+    );
+
+    let mut signatures = Vec::new();
+    for message in &remote_messages {
+        if signatures.contains(&message.signature) {
+            panic!(
+                "Duplicate remote message found with signature {}",
+                message.signature
+            );
+        } else {
+            signatures.push(message.signature.clone());
+        }
+    }
+}

--- a/test-runner/src/topics.rs
+++ b/test-runner/src/topics.rs
@@ -1,0 +1,117 @@
+use poi_radio::state::PersistedState;
+use test_utils::{
+    config::{test_config, TestSenderConfig},
+    setup, teardown,
+};
+use tokio::time::{sleep, Duration};
+use tracing::debug;
+
+pub async fn topics_test() {
+    let test_file_name = "topics";
+    let store_path = format!("./test-runner/state/{}.json", test_file_name);
+
+    let radio_topics = vec![
+        "Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string(),
+        "Qmdefault2XyZABCdefGHIjklMNOpqrstuvWXYZabcdefGHIJKLMN".to_string(),
+        "QmonlyinradioXyZABCdeFgHIjklMNOpqrstuvWXYZabcdefGHIJKL".to_string(),
+    ];
+
+    let test_sender_topics = vec![
+        "Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string(),
+        "Qmdefault2XyZABCdefGHIjklMNOpqrstuvWXYZabcdefGHIJKLMN".to_string(),
+        "QmonlyintestsenderXyZABCdeFgHIjklMNOpqrstuvWXYZabcdEFG".to_string(),
+    ];
+
+    let mut config = test_config();
+    config.persistence_file_path = Some(store_path.clone());
+    config.topics = radio_topics.clone();
+    config.topic_update_interval = 90;
+
+    let mut test_sender_config = TestSenderConfig {
+        topics: test_sender_topics,
+        radio_name: String::new(),
+        block_hash: None,
+        staked_tokens: None,
+        nonce: None,
+        radio_payload: None,
+    };
+
+    let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
+
+    sleep(Duration::from_secs(89)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    let local_attestations = persisted_state.local_attestations();
+    let remote_messages = persisted_state.remote_messages();
+
+    debug!("Starting topics_test");
+
+    assert!(
+        !local_attestations.is_empty(),
+        "There should be at least one element in local_attestations"
+    );
+
+    for test_hash in radio_topics {
+        assert!(
+            local_attestations.contains_key(&test_hash),
+            "No attestation found with ipfs hash {}",
+            test_hash
+        );
+    }
+
+    let test_hashes_remote = vec![
+        "Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq",
+        "Qmdefault2XyZABCdefGHIjklMNOpqrstuvWXYZabcdefGHIJKLMN",
+    ];
+
+    for target_id in test_hashes_remote {
+        let has_target_id = remote_messages
+            .iter()
+            .any(|msg| msg.identifier == *target_id);
+        assert!(
+            has_target_id,
+            "No remote message found with identifier {}",
+            target_id
+        );
+    }
+
+    let non_existent_test_hash = "QmonlyintestsenderXyZABCdeFgHIjklMNOpqrstuvWXYZabcdEFG";
+
+    let has_non_existent_test_hash = remote_messages
+        .iter()
+        .any(|msg| msg.identifier == non_existent_test_hash);
+
+    assert!(
+        !has_non_existent_test_hash,
+        "Unexpected remote message found with identifier {}",
+        non_existent_test_hash
+    );
+
+    let new_subgraphs = vec!["QmonlyintestsenderXyZABCdeFgHIjklMNOpqrstuvWXYZabcdEFG".to_string()]; // change this to your new subgraphs
+    process_manager
+        .server_state
+        .update_subgraphs(new_subgraphs)
+        .await;
+
+    tokio::time::sleep(Duration::from_secs(50)).await;
+
+    let persisted_state = PersistedState::load_cache(&store_path);
+    debug!("persisted state {:?}", persisted_state);
+
+    let remote_messages = persisted_state.remote_messages();
+
+    let test_hash = "QmonlyintestsenderXyZABCdeFgHIjklMNOpqrstuvWXYZabcdEFG";
+    let has_test_hash = remote_messages
+        .iter()
+        .any(|msg| msg.identifier == test_hash);
+
+    assert!(
+        has_test_hash,
+        "Expected remote message not found with identifier {}",
+        test_hash
+    );
+
+    teardown(process_manager, &store_path);
+}

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -23,6 +23,7 @@ categories = [
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
 graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
+test-utils = { path = "../test-utils" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"
@@ -33,3 +34,9 @@ axum = "0.5"
 tower-http = { version = "0.4.0", features = ["trace", "cors"] }
 tower = "0.4.13"
 ring = "0.16.19"
+serde = { version = "1.0.163", features = ["rc"] }
+serde_json = "1.0.96"
+serde_derive = "1.0"
+clap = { version = "3.2.25", features = ["derive"] }
+prost = "0.11.9"
+ethers = "2.0.7"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -32,3 +32,14 @@ chrono = "0.4"
 axum = "0.5"
 tower-http = { version = "0.4.0", features = ["trace", "cors"] }
 tower = "0.4.13"
+uuid = "1.3.3"
+serde = { version = "1.0.163", features = ["rc"] }
+serde_json = "1.0.96"
+serde_derive = "1.0"
+clap = { version = "3.2.25", features = ["derive"] }
+prost = "0.11"
+ethers = "2.0.4"
+ethers-contract = "2.0.4"
+ethers-core = "2.0.4"
+ethers-derive-eip712 = "1.0.2"
+async-graphql = "4.0.16"

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -1,30 +1,37 @@
-use std::env;
-
+use clap::{ArgSettings, Parser};
 use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
 use poi_radio::config::{Config, CoverageLevel};
+use serde::{Deserialize, Serialize};
 
-pub fn test_config(
-    graph_node_endpoint: String,
-    registry_subgraph: String,
-    network_subgraph: String,
-) -> Config {
-    let id = env::var("TEST_RUN_ID").unwrap_or_else(|_| panic!("TEST_RUN_ID not set"));
-    let radio_name = format!("poi-radio-test-{}", id);
+#[derive(Clone, Debug, Parser, Serialize, Deserialize)]
+#[clap(name = "test-sender", about = "Mock message sender")]
+pub struct TestSenderConfig {
+    #[clap(long, value_name = "TOPICS", help = "Topics for test messages", setting = ArgSettings::UseValueDelimiter)]
+    pub topics: Vec<String>,
+    #[clap(long, value_name = "RADIO_NAME", help = "Instance-specific radio name")]
+    pub radio_name: String,
+    #[clap(long, value_name = "BLOCK_HASH")]
+    pub block_hash: Option<String>,
+    #[clap(long, value_name = "SENDER_TOKENS")]
+    pub staked_tokens: Option<String>,
+    #[clap(long, value_name = "NONCE")]
+    pub nonce: Option<String>,
+    #[clap(long, value_name = "RADIO_PAYLOAD")]
+    pub radio_payload: Option<String>,
+}
 
+pub fn test_config() -> Config {
     Config {
-        graph_node_endpoint,
         indexer_address: String::from("0x7e6528e4ce3055e829a32b5dc4450072bac28bc6"),
+        graph_node_endpoint: String::new(),
         private_key: Some(
             "ccaea3e3aca412cb3920dbecd77bc725dfe9a5e16f940f19912d9c9dbee01e8f".to_string(),
         ),
         mnemonic: None,
-        registry_subgraph,
-        network_subgraph,
+        registry_subgraph: String::new(),
+        network_subgraph: String::new(),
         graphcast_network: "testnet".to_string(),
-        topics: vec![
-            "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE".to_string(),
-            "QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE".to_string(),
-        ],
+        topics: vec![],
         coverage: CoverageLevel::OnChain,
         collect_message_duration: 60,
         waku_host: None,
@@ -33,7 +40,7 @@ pub fn test_config(
         waku_addr: None,
         boot_node_addresses: vec![],
         waku_log_level: None,
-        log_level: "off,hyper=off,graphcast_sdk=trace,poi_radio=trace,poi-radio-e2e-tests=trace"
+        log_level: "off,hyper=off,graphcast_sdk=trace,poi_radio=trace,test_runner=trace"
             .to_string(),
         slack_token: None,
         slack_channel: None,
@@ -42,14 +49,15 @@ pub fn test_config(
         metrics_port: None,
         server_host: String::new(),
         server_port: None,
-        persistence_file_path: Some("./test-runner/state.json".to_string()),
+        persistence_file_path: None,
         log_format: "pretty".to_string(),
-        radio_name,
+        radio_name: String::new(),
         telegram_chat_id: None,
         telegram_token: None,
         discv5_enrs: None,
         discv5_port: None,
         filter_protocol: None,
-        id_validation: Some(IdentityValidation::ValidAddress),
+        id_validation: Some(IdentityValidation::GraphcastRegistered),
+        topic_update_interval: 600,
     }
 }

--- a/test-utils/src/dummy_msg.rs
+++ b/test-utils/src/dummy_msg.rs
@@ -1,0 +1,44 @@
+use async_graphql::SimpleObject;
+use ethers_contract::EthAbiType;
+use ethers_core::types::transaction::eip712::Eip712;
+use ethers_derive_eip712::*;
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+#[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, SimpleObject)]
+#[eip712(
+    name = "Graphcast POI Radio Dummy Msg",
+    version = "0",
+    chain_id = 1,
+    verifying_contract = "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
+)]
+pub struct DummyMsg {
+    #[prost(string, tag = "1")]
+    pub identifier: String,
+    #[prost(int32, tag = "2")]
+    pub dummy_value: i32,
+}
+
+impl DummyMsg {
+    pub fn new(identifier: String, dummy_value: i32) -> Self {
+        DummyMsg {
+            identifier,
+            dummy_value,
+        }
+    }
+
+    pub fn from_ref(dummy_msg: &DummyMsg) -> Self {
+        DummyMsg {
+            identifier: dummy_msg.identifier.clone(),
+            dummy_value: dummy_msg.dummy_value,
+        }
+    }
+
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+
+    pub fn from_json(s: &str) -> Self {
+        serde_json::from_str(s).unwrap()
+    }
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,17 +1,254 @@
+use std::{
+    fs,
+    net::{TcpListener, UdpSocket},
+    path::Path,
+    process::{Child, Command},
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
+};
+
+use chrono::Utc;
+use config::TestSenderConfig;
+use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
+use mock_server::{start_mock_server, ServerState};
+use poi_radio::config::{Config, CoverageLevel};
+use rand::Rng;
+use tracing::info;
+
 pub mod config;
+pub mod dummy_msg;
 pub mod mock_server;
 
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+pub struct ProcessManager {
+    pub senders: Vec<Arc<Mutex<Child>>>,
+    pub radio: Arc<Mutex<Child>>,
+    pub server_state: ServerState,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl Drop for ProcessManager {
+    fn drop(&mut self) {
+        let _ = self.senders.get(0).unwrap().lock().unwrap().kill();
+        let _ = self.radio.lock().unwrap().kill();
     }
+}
+
+fn find_random_tcp_port() -> u16 {
+    let mut rng = rand::thread_rng();
+    let mut port = 0;
+
+    for _ in 0..10 {
+        // Generate a random port number within the range 49152 to 65535
+        let test_port = rng.gen_range(49152..=65535);
+        match TcpListener::bind(("0.0.0.0", test_port)) {
+            Ok(_) => {
+                port = test_port;
+                break;
+            }
+            Err(_) => {
+                println!("Port {} is not available, retrying...", test_port);
+                thread::sleep(Duration::from_secs(1));
+                continue;
+            }
+        }
+    }
+
+    if port == 0 {
+        panic!("Could not find a free port");
+    }
+
+    port
+}
+
+pub async fn setup(
+    config: &Config,
+    test_file_name: &str,
+    test_sender_config: &mut TestSenderConfig,
+) -> ProcessManager {
+    if let Some(file_path) = &config.persistence_file_path {
+        let path = Path::new(file_path);
+        if path.exists() {
+            fs::remove_file(path).expect("Failed to remove file");
+        }
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let radio_name = format!("{}-{}", test_file_name, id);
+    test_sender_config.radio_name = radio_name.clone();
+
+    let basic_sender = Arc::new(Mutex::new(
+        Command::new("cargo")
+            .arg("run")
+            .arg("-p")
+            .arg("test-sender")
+            .arg("--")
+            .arg("--topics")
+            .arg(&test_sender_config.topics.join(","))
+            .arg("--radio-name")
+            .arg(&test_sender_config.radio_name)
+            .arg("--block-hash")
+            .arg(&test_sender_config.block_hash.clone().unwrap_or(
+                "4dbba1ba9fb18b0034965712598be1368edcf91ae2c551d59462aab578dab9c5".to_string(),
+            ))
+            .arg("--nonce")
+            .arg(
+                &test_sender_config
+                    .nonce
+                    .clone()
+                    .unwrap_or(Utc::now().timestamp().to_string()),
+            )
+            .arg("--radio-payload")
+            .arg(
+                test_sender_config
+                    .radio_payload
+                    .clone()
+                    .unwrap_or("radio_payload_message".to_string()),
+            )
+            .spawn()
+            .expect("Failed to start command"),
+    ));
+
+    let waku_port = find_random_udp_port();
+    let discv5_port = find_random_udp_port();
+
+    // TODO: Consider adding helper functions here
+    let mut config = config.clone();
+
+    let port = find_random_tcp_port();
+    let host = format!("127.0.0.1:{}", port);
+    let server_state = start_mock_server(
+        host.clone(),
+        config.topics.clone(),
+        test_sender_config.staked_tokens.clone(),
+    )
+    .await;
+
+    config.graph_node_endpoint = format!("http://{}/graphql", host);
+    config.registry_subgraph = format!("http://{}/registry-subgraph", host);
+    config.network_subgraph = format!("http://{}/network-subgraph", host);
+    config.radio_name = radio_name;
+    config.waku_port = Some(waku_port.to_string());
+    config.discv5_port = Some(discv5_port);
+
+    info!(
+        "Starting POI Radio instance on port {}",
+        waku_port.to_string()
+    );
+
+    let radio = Arc::new(Mutex::new(start_radio(&config)));
+
+    ProcessManager {
+        senders: vec![Arc::clone(&basic_sender)],
+        radio: Arc::clone(&radio),
+        server_state,
+    }
+}
+
+pub fn teardown(process_manager: ProcessManager, store_path: &str) {
+    // Kill the processes
+    for sender in &process_manager.senders {
+        let _ = sender.lock().unwrap().kill();
+    }
+    let _ = process_manager.radio.lock().unwrap().kill();
+
+    if Path::new(&store_path).exists() {
+        fs::remove_file(store_path).unwrap();
+    }
+}
+
+pub fn start_radio(config: &Config) -> Child {
+    Command::new("cargo")
+        .arg("run")
+        .arg("-p")
+        .arg("poi-radio")
+        .arg("--")
+        .arg("--graph-node-endpoint")
+        .arg(&config.graph_node_endpoint)
+        .arg("--private-key")
+        .arg(config.private_key.as_deref().unwrap_or("None"))
+        .arg("--registry-subgraph")
+        .arg(&config.registry_subgraph)
+        .arg("--network-subgraph")
+        .arg(&config.network_subgraph)
+        .arg("--graphcast-network")
+        .arg(&config.graphcast_network)
+        .arg("--topics")
+        .arg(config.topics.join(","))
+        .arg("--coverage")
+        .arg(match config.coverage {
+            CoverageLevel::Minimal => "minimal",
+            CoverageLevel::OnChain => "on-chain",
+            CoverageLevel::Comprehensive => "comprehensive",
+        })
+        .arg("--collect-message-duration")
+        .arg(config.collect_message_duration.to_string())
+        .arg("--waku-log-level")
+        .arg(config.waku_log_level.as_deref().unwrap_or("None"))
+        .arg("--waku-port")
+        .arg(config.waku_port.as_deref().unwrap_or("None"))
+        .arg("--log-level")
+        .arg(&config.log_level)
+        .arg("--slack-token")
+        .arg(config.slack_token.as_deref().unwrap_or("None"))
+        .arg("--slack-channel")
+        .arg(config.slack_channel.as_deref().unwrap_or("None"))
+        .arg("--discord-webhook")
+        .arg(config.discord_webhook.as_deref().unwrap_or("None"))
+        .arg("--persistence-file-path")
+        .arg(config.persistence_file_path.as_deref().unwrap_or("None"))
+        .arg("--log-format")
+        .arg(&config.log_format)
+        .arg("--radio-name")
+        .arg(&config.radio_name)
+        .arg("--topic-update-interval")
+        .arg(&config.topic_update_interval.to_string())
+        .arg("--discv5-port")
+        .arg(
+            config
+                .discv5_port
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "None".to_string()),
+        )
+        .arg("--indexer-address")
+        .arg(&config.indexer_address)
+        .arg("--id-validation")
+        .arg(
+            match config
+                .id_validation
+                .clone()
+                .unwrap_or(IdentityValidation::RegisteredIndexer)
+            {
+                IdentityValidation::NoCheck => "no-check",
+                IdentityValidation::ValidAddress => "valid-address",
+                IdentityValidation::GraphcastRegistered => "graphcast-registered",
+                IdentityValidation::GraphNetworkAccount => "graph-network-account",
+                IdentityValidation::RegisteredIndexer => "registered-indexer",
+                IdentityValidation::Indexer => "indexer",
+            },
+        )
+        .spawn()
+        .expect("Failed to start command")
+}
+
+pub fn find_random_udp_port() -> u16 {
+    let mut rng = rand::thread_rng();
+    let mut port = 0;
+
+    for _ in 0..10 {
+        // Generate a random port number within the range 49152 to 65535
+        let test_port = rng.gen_range(49152..=65535);
+        match UdpSocket::bind(("0.0.0.0", test_port)) {
+            Ok(_) => {
+                port = test_port;
+                break;
+            }
+            Err(_) => continue,
+        }
+    }
+
+    if port == 0 {
+        panic!("Could not find a free port");
+    }
+
+    port
 }

--- a/test-utils/src/mock_server.rs
+++ b/test-utils/src/mock_server.rs
@@ -2,37 +2,81 @@ use axum::{routing::post, Router};
 use chrono::Utc;
 use rand::Rng;
 use std::fmt::Write;
+use std::sync::Arc;
 use std::{convert::Infallible, net::SocketAddr, str::FromStr};
+use tokio::sync::Mutex;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
-pub async fn start_mock_server(address: &str) {
-    // Define the HTTP handlers
+pub struct ServerState {
+    subgraphs: Arc<Mutex<Vec<String>>>,
+}
+
+impl ServerState {
+    pub async fn update_subgraphs(&self, new_subgraphs: Vec<String>) {
+        let mut subgraphs = self.subgraphs.lock().await;
+        *subgraphs = new_subgraphs;
+    }
+}
+
+pub async fn start_mock_server(
+    address: String,
+    initial_subgraphs: Vec<String>,
+    staked_tokens: Option<String>,
+) -> ServerState {
+    let subgraphs = Arc::new(Mutex::new(initial_subgraphs));
+
+    // Define cloned versions of subgraphs here
+    let subgraphs_for_graphql = Arc::clone(&subgraphs);
+    let subgraphs_for_network_subgraph = Arc::clone(&subgraphs);
+
     let app = Router::new()
-        .route("/graphql", post(handler_graphql))
+        .route(
+            "/graphql",
+            post(move || handler_graphql(subgraphs_for_graphql.clone())),
+        )
         .route("/registry-subgraph", post(handler_graphcast_registry))
-        .route("/network-subgraph", post(handler_network_subgraph)) // Added this line
+        .route(
+            "/network-subgraph",
+            post(move || {
+                handler_network_subgraph(
+                    subgraphs_for_network_subgraph.clone(),
+                    staked_tokens.unwrap_or("10000000000000000000000".to_string()),
+                )
+            }),
+        )
         .layer(
             ServiceBuilder::new()
                 .layer(TraceLayer::new_for_http())
                 .into_inner(),
         );
 
-    // Create the server and start listening for requests
-    let addr = SocketAddr::from_str(address).unwrap();
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let addr = SocketAddr::from_str(&address).unwrap();
+    tokio::spawn(axum::Server::bind(&addr).serve(app.into_make_service()));
+
+    ServerState { subgraphs }
 }
 
-async fn handler_graphql() -> Result<String, Infallible> {
+async fn handler_graphql(subgraphs: Arc<Mutex<Vec<String>>>) -> Result<String, Infallible> {
     let timestamp = Utc::now().timestamp();
     let timestamp = (timestamp + 9) / 10 * 10;
+    let subgraphs = subgraphs.lock().await;
+
+    // Prepare indexingStatuses part of the response dynamically from the subgraphs vector
+    let indexing_statuses: Vec<String> = subgraphs
+        .iter()
+        .map(|hash| format!(
+            r#"{{"subgraph": "{}", "synced": true, "health": "healthy", "node": "default", "fatalError": null, "chains": [{{"network": "mainnet", "latestBlock": {{"number": "{}", "hash": "b30395958a317ccc06da46782f660ce674cbe6792e5573dc630978c506114a0a"}}, "chainHeadBlock": {{"number": "{}", "hash": "b30395958a317ccc06da46782f660ce674cbe6792e5573dc630978c506114a0a"}}}}]}}"#,
+            hash, timestamp, timestamp
+        ))
+        .collect();
+
+    // Prepare indexingStatuses part of the response by joining individual status strings with comma
+    let indexing_statuses = indexing_statuses.join(",");
 
     let response_body = format!(
-        r#"{{"data": {{"proofOfIndexing": "0x25331f98b82ca7f3966256bf508a7ede52e715b631dfa3d73b846bb7617f6b9e", "blockHashFromNumber": "4dbba1ba9fb18b0034965712598be1368edcf91ae2c551d59462aab578dab9c5", "indexingStatuses": [{{"subgraph": "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE", "synced": true, "health": "healthy", "node": "default", "fatalError": null, "chains": [{{"network": "mainnet", "latestBlock": {{"number": "{}", "hash": "b30395958a317ccc06da46782f660ce674cbe6792e5573dc630978c506114a0a"}}, "chainHeadBlock": {{"number": "{}", "hash": "b30395958a317ccc06da46782f660ce674cbe6792e5573dc630978c506114a0a"}}}}]}}, {{"subgraph": "QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE", "synced": true, "health": "healthy", "node": "default", "fatalError": null, "chains": [{{"network": "goerli", "latestBlock": {{"number": "{}", "hash": "b30395958a317ccc06da46782f660ce674cbe6792e5573dc630978c506114a0a"}}, "chainHeadBlock": {{"number": "{}", "hash": "b30395958a317ccc06da46782f660ce674cbe6792e5573dc630978c506114a0a"}}}}]}}]}}}}"#,
-        timestamp, timestamp, timestamp, timestamp
+        r#"{{"data": {{"proofOfIndexing": "0x25331f98b82ca7f3966256bf508a7ede52e715b631dfa3d73b846bb7617f6b9e", "blockHashFromNumber": "4dbba1ba9fb18b0034965712598be1368edcf91ae2c551d59462aab578dab9c5", "indexingStatuses": [{}]}}}}"#,
+        indexing_statuses
     );
 
     Ok(response_body)
@@ -78,31 +122,37 @@ async fn handler_graphcast_registry() -> Result<String, Infallible> {
     Ok(response_body)
 }
 
-async fn handler_network_subgraph() -> Result<String, Infallible> {
-    let response_body = r#"
-    {
-        "data": {
-            "indexer": {
-                "stakedTokens": "10000000000000000000000",
-                "allocations": [
-                    {
-                        "subgraphDeployment": {
-                            "ipfsHash": "QmpRkaVUwUQAwPwWgdQHYvw53A5gh3CP3giWnWQZdA2BTE"
-                        }
-                    },
-                    {
-                        "subgraphDeployment": {
-                            "ipfsHash": "QmtYT8NhPd6msi1btMc3bXgrfhjkJoC4ChcM5tG6fyLjHE"
-                        }
-                    }
-                ]
-            },
-            "graphNetwork": {
-                "minimumIndexerStake": "10000000000000000000000"
-            }
-        },
-        "errors": null
-    }"#;
+async fn handler_network_subgraph(
+    subgraphs: Arc<Mutex<Vec<String>>>,
+    staked_tokens: String,
+) -> Result<String, Infallible> {
+    let subgraphs = subgraphs.lock().await;
 
-    Ok(response_body.to_string())
+    // Prepare allocations part of the response dynamically from the subgraphs vector
+    let allocations: Vec<String> = subgraphs
+        .iter()
+        .map(|hash| format!(r#"{{"subgraphDeployment": {{"ipfsHash": "{}"}}}}"#, hash))
+        .collect();
+
+    // Prepare allocations part of the response by joining individual allocation strings with comma
+    let allocations = allocations.join(",");
+
+    let response_body = format!(
+        r#"
+        {{
+            "data": {{
+                "indexer": {{
+                    "stakedTokens": "{}",
+                    "allocations": [{}]
+                }},
+                "graphNetwork": {{
+                    "minimumIndexerStake": "10000000000000000000000"
+                }}
+            }},
+            "errors": null
+        }}"#,
+        staked_tokens, allocations
+    );
+
+    Ok(response_body)
 }


### PR DESCRIPTION
### Description

Reached feature parity with old tests. Tests can be started using `cargo run -p test-runner`, they take about `230`s on average to complete.

### Issue link (if applicable)

[Link to issue](https://github.com/graphops/poi-radio/issues/175)
