### PR TITLE
Persist comparison results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1433,7 +1433,7 @@ version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
- "der 0.7.6",
+ "der 0.7.7",
  "digest 0.10.7",
  "elliptic-curve 0.13.5",
  "rfc6979 0.4.0",
@@ -2574,15 +2574,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -3367,11 +3358,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "libc",
 ]
 
@@ -3804,7 +3795,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.6",
+ "der 0.7.7",
  "spki 0.7.2",
 ]
 
@@ -4071,9 +4062,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -4607,7 +4598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.6",
+ "der 0.7.7",
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
@@ -5072,7 +5063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.6",
+ "der 0.7.7",
 ]
 
 [[package]]
@@ -5354,8 +5345,6 @@ dependencies = [
  "graphcast-sdk",
  "poi-radio",
  "prost",
- "rand 0.8.5",
- "ring",
  "serde",
  "serde_derive",
  "serde_json",

--- a/poi-radio/src/config.rs
+++ b/poi-radio/src/config.rs
@@ -400,7 +400,7 @@ impl Config {
             state
         } else {
             debug!("Created new state");
-            PersistedState::new(None, None)
+            PersistedState::new(None, None, None)
         }
     }
 

--- a/poi-radio/src/operator/mod.rs
+++ b/poi-radio/src/operator/mod.rs
@@ -1,5 +1,4 @@
 use derive_getters::Getters;
-use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex as SyncMutex};
 use std::thread;
@@ -207,8 +206,6 @@ impl RadioOperator {
             skip_iteration_clone.store(true, Ordering::SeqCst);
         });
 
-        let mut divergent_subgraphs: HashSet<String> = HashSet::new();
-
         // Initialize Http server with graceful shutdown if configured
         if self.config.server_port().is_some() {
             let state_ref = &self.persisted_state;
@@ -345,8 +342,8 @@ impl RadioOperator {
                             blocks_str,
                             identifiers.len(),
                             comparison_res,
-                            &mut divergent_subgraphs,
-                            self.notifier.clone()
+                            self.notifier.clone(),
+                            self.persisted_state.clone()
                         )
                     }).await;
 

--- a/test-runner/src/invalid_block_hash.rs
+++ b/test-runner/src/invalid_block_hash.rs
@@ -28,6 +28,7 @@ pub async fn invalid_block_hash_test() {
         staked_tokens: None,
         nonce: None,
         radio_payload: None,
+        poi: None,
     };
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;

--- a/test-runner/src/invalid_nonce.rs
+++ b/test-runner/src/invalid_nonce.rs
@@ -26,6 +26,7 @@ pub async fn invalid_nonce_test() {
         staked_tokens: None,
         nonce: Some("1655850000".to_string()),
         radio_payload: None,
+        poi: None,
     };
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;

--- a/test-runner/src/invalid_payload.rs
+++ b/test-runner/src/invalid_payload.rs
@@ -31,6 +31,7 @@ pub async fn invalid_payload_test() {
         staked_tokens: None,
         nonce: None,
         radio_payload: Some(DummyMsg::to_json(&dummy_radio_payload)),
+        poi: None,
     };
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;

--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -3,4 +3,6 @@ pub mod invalid_nonce;
 pub mod invalid_payload;
 pub mod invalid_sender;
 pub mod message_handling;
+pub mod poi_divergent;
+pub mod poi_match;
 pub mod topics;

--- a/test-runner/src/poi_divergent.rs
+++ b/test-runner/src/poi_divergent.rs
@@ -1,5 +1,4 @@
-use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
-use poi_radio::state::PersistedState;
+use poi_radio::{operator::attestation::ComparisonResultType, state::PersistedState};
 use test_utils::{
     config::{test_config, TestSenderConfig},
     setup, teardown,
@@ -7,8 +6,8 @@ use test_utils::{
 use tokio::time::{sleep, Duration};
 use tracing::debug;
 
-pub async fn invalid_sender_test() {
-    let test_file_name = "invalid_sender";
+pub async fn poi_divergent_test() {
+    let test_file_name = "poi_divergent";
     let store_path = format!("./test-runner/state/{}.json", test_file_name);
 
     let radio_topics = vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
@@ -19,30 +18,40 @@ pub async fn invalid_sender_test() {
     let mut config = test_config();
     config.persistence_file_path = Some(store_path.clone());
     config.topics = radio_topics.clone();
-    config.id_validation = Some(IdentityValidation::RegisteredIndexer);
 
     let mut test_sender_config = TestSenderConfig {
         topics: test_sender_topics,
         radio_name: String::new(),
         block_hash: None,
-        staked_tokens: Some("1".to_string()),
+        staked_tokens: None,
         nonce: None,
         radio_payload: None,
-        poi: None,
+        poi: Some("0x8a937e93f72bf4396214fd519e3ded51a7f3b4316ada7b87d246b4626f7e9e8d".to_string()),
     };
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
 
-    sleep(Duration::from_secs(89)).await;
+    sleep(Duration::from_secs(300)).await;
 
     let persisted_state = PersistedState::load_cache(&store_path);
     debug!("persisted state {:?}", persisted_state);
 
-    teardown(process_manager, &store_path);
+    let comparison_results = persisted_state.comparison_results();
 
-    let remote_messages = persisted_state.remote_messages();
     assert!(
-        remote_messages.is_empty(),
-        "Remote messages should be empty"
+        !comparison_results.is_empty(),
+        "The comparison results should not be empty"
     );
+
+    let has_divergent_result = comparison_results.iter().any(|result| {
+        result.1.deployment == "Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq"
+            && result.1.result_type == ComparisonResultType::Divergent
+    });
+
+    assert!(
+        has_divergent_result,
+        "No comparison result found with deployment 'Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq' and result type 'Divergent'"
+    );
+
+    teardown(process_manager, &store_path);
 }

--- a/test-runner/src/poi_match.rs
+++ b/test-runner/src/poi_match.rs
@@ -1,5 +1,4 @@
-use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
-use poi_radio::state::PersistedState;
+use poi_radio::{operator::attestation::ComparisonResultType, state::PersistedState};
 use test_utils::{
     config::{test_config, TestSenderConfig},
     setup, teardown,
@@ -7,8 +6,8 @@ use test_utils::{
 use tokio::time::{sleep, Duration};
 use tracing::debug;
 
-pub async fn invalid_sender_test() {
-    let test_file_name = "invalid_sender";
+pub async fn poi_match_test() {
+    let test_file_name = "poi_match";
     let store_path = format!("./test-runner/state/{}.json", test_file_name);
 
     let radio_topics = vec!["Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq".to_string()];
@@ -19,13 +18,12 @@ pub async fn invalid_sender_test() {
     let mut config = test_config();
     config.persistence_file_path = Some(store_path.clone());
     config.topics = radio_topics.clone();
-    config.id_validation = Some(IdentityValidation::RegisteredIndexer);
 
     let mut test_sender_config = TestSenderConfig {
         topics: test_sender_topics,
         radio_name: String::new(),
         block_hash: None,
-        staked_tokens: Some("1".to_string()),
+        staked_tokens: None,
         nonce: None,
         radio_payload: None,
         poi: None,
@@ -33,16 +31,27 @@ pub async fn invalid_sender_test() {
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
 
-    sleep(Duration::from_secs(89)).await;
+    sleep(Duration::from_secs(300)).await;
 
     let persisted_state = PersistedState::load_cache(&store_path);
     debug!("persisted state {:?}", persisted_state);
 
-    teardown(process_manager, &store_path);
+    let comparison_results = persisted_state.comparison_results();
 
-    let remote_messages = persisted_state.remote_messages();
     assert!(
-        remote_messages.is_empty(),
-        "Remote messages should be empty"
+        !comparison_results.is_empty(),
+        "The comparison results should not be empty"
     );
+
+    let has_match_result = comparison_results.iter().any(|result| {
+        result.1.deployment == "Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq"
+            && result.1.result_type == ComparisonResultType::Match
+    });
+
+    assert!(
+        has_match_result,
+        "No comparison result found with deployment 'Qmdefault1AbcDEFghijKLmnoPQRstUVwxYzABCDEFghijklmnopq' and result type 'Match'"
+    );
+
+    teardown(process_manager, &store_path);
 }

--- a/test-runner/src/topics.rs
+++ b/test-runner/src/topics.rs
@@ -34,6 +34,7 @@ pub async fn topics_test() {
         staked_tokens: None,
         nonce: None,
         radio_payload: None,
+        poi: None,
     };
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -28,12 +28,10 @@ poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-rand = "0.8.3"
 chrono = "0.4"
 axum = "0.5"
 tower-http = { version = "0.4.0", features = ["trace", "cors"] }
 tower = "0.4.13"
-ring = "0.16.19"
 serde = { version = "1.0.163", features = ["rc"] }
 serde_json = "1.0.96"
 serde_derive = "1.0"

--- a/test-sender/src/main.rs
+++ b/test-sender/src/main.rs
@@ -12,29 +12,11 @@ use graphcast_sdk::{
     networks::NetworkName,
 };
 use poi_radio::RadioPayloadMessage;
-use rand::RngCore;
-use ring::digest;
 use test_utils::{config::TestSenderConfig, dummy_msg::DummyMsg, find_random_udp_port};
 use tracing::{error, info};
 use waku::{
     waku_new, GossipSubParams, ProtocolId, WakuContentTopic, WakuNodeConfig, WakuPubSubTopic,
 };
-
-fn generate_random_poi() -> String {
-    let mut rng = rand::thread_rng();
-    let mut input = [0u8; 32]; // 32 bytes for SHA-256
-
-    rng.fill_bytes(&mut input);
-
-    let hash = digest::digest(&digest::SHA256, &input);
-
-    let mut hash_string = String::from("0x");
-    for byte in hash.as_ref() {
-        hash_string.push_str(&format!("{:02x}", byte));
-    }
-
-    hash_string
-}
 
 async fn start_sender(config: TestSenderConfig) {
     std::env::set_var(
@@ -103,7 +85,7 @@ async fn start_sender(config: TestSenderConfig) {
             match radio_payload_clone.as_deref() {
                 Some("radio_payload_message") => {
                     let radio_payload =
-                        RadioPayloadMessage::new(topic.clone(), generate_random_poi());
+                        RadioPayloadMessage::new(topic.clone(), config.poi.clone().unwrap());
 
                     let mut graphcast_message = GraphcastMessage::build(
                         &wallet,

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -18,6 +18,8 @@ pub struct TestSenderConfig {
     pub nonce: Option<String>,
     #[clap(long, value_name = "RADIO_PAYLOAD")]
     pub radio_payload: Option<String>,
+    #[clap(long, value_name = "POI")]
+    pub poi: Option<String>,
 }
 
 pub fn test_config() -> Config {


### PR DESCRIPTION
### Description

Adds support for persisting POI comparison results to the local JSON store, also improves notification logic. Comparison results are added to the existing `PersistedState` struct:
```
pub struct PersistedState {
    pub local_attestations: Local,
    pub remote_messages: Remote,
    pub comparison_results: ComparisonResults,
}
```
And are of type `type ComparisonResults = Arc<SyncMutex<HashMap<String, ComparisonResult>>>`, which resembles the way `local_attestations` are stored. 

The divergence notifications logic has been moved to `handle_comparison_result`, which should now take each incoming comparison result and update the state + send a notification if needed.

New simple e2e tests have been added to check if the state is properly representing the Match and Diverged cases.

Related issues
https://github.com/graphops/poi-radio/issues/169
https://github.com/graphops/poi-radio/issues/178