### PR TITLE
refactor: comparison results query resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.3.4"
-source = "git+https://github.com/graphops/graphcast-sdk#60e2999049fd91dbb0abacb60f2e7b08aa034096"
+source = "git+https://github.com/graphops/graphcast-sdk?branch=hope/msg-restructure#6194718b22843d551e9a5d3acb451825376efc0e"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2868,7 +2868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.2",
+ "rustix 0.38.3",
  "windows-sys",
 ]
 
@@ -4420,9 +4420,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.22"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -4434,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -5313,7 +5313,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.22",
+ "rustix 0.37.23",
  "windows-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.3.4"
-source = "git+https://github.com/graphops/graphcast-sdk?rev=7b4be3b#7b4be3b67663644f15351ee9902c15638811b79a"
+source = "git+https://github.com/graphops/graphcast-sdk#d0e383d06b94cc27cc3f0e00744443cc7a98f8b6"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.3.4"
-source = "git+https://github.com/graphops/graphcast-sdk?branch=hope/msg-restructure#6194718b22843d551e9a5d3acb451825376efc0e"
+source = "git+https://github.com/graphops/graphcast-sdk?rev=7b4be3b#7b4be3b67663644f15351ee9902c15638811b79a"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/poi-radio/Cargo.toml
+++ b/poi-radio/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories = ["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
 prost = "0.11"
 once_cell = "1.17"
 chrono = "0.4"

--- a/poi-radio/Cargo.toml
+++ b/poi-radio/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories = ["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 prost = "0.11"
 once_cell = "1.17"
 chrono = "0.4"

--- a/poi-radio/Cargo.toml
+++ b/poi-radio/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories = ["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
 prost = "0.11"
 once_cell = "1.17"
 chrono = "0.4"

--- a/poi-radio/benches/attestations.rs
+++ b/poi-radio/benches/attestations.rs
@@ -4,8 +4,12 @@ extern crate criterion;
 
 mod attestation {
     use criterion::{black_box, criterion_group, Criterion};
-    use poi_radio::operator::attestation::{
-        compare_attestations, local_comparison_point, update_blocks, Attestation,
+    use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
+    use poi_radio::{
+        operator::attestation::{
+            compare_attestations, local_comparison_point, update_blocks, Attestation,
+        },
+        RadioPayloadMessage,
     };
     use std::collections::HashMap;
 
@@ -130,8 +134,28 @@ mod attestation {
         let local: HashMap<String, HashMap<u64, Attestation>> = black_box(local_attestations);
 
         c.bench_function("comparison_point", |b| {
-            b.iter(|| local_comparison_point(black_box(&local), "hash".to_string(), 120))
+            b.iter(|| {
+                local_comparison_point(black_box(&local), &test_msg_vec(), "hash".to_string(), 120)
+            })
         });
+    }
+
+    pub fn test_msg_vec() -> Vec<GraphcastMessage<RadioPayloadMessage>> {
+        vec![GraphcastMessage {
+            identifier: String::from("hash"),
+            nonce: 2,
+            graph_account: String::from("0x7e6528e4ce3055e829a32b5dc4450072bac28bc6"),
+            payload: RadioPayloadMessage {
+                identifier: String::from("hash"),
+                content: String::from("awesome-npoi"),
+                nonce: 2,
+                network: String::from("goerli"),
+                block_number: 42,
+                block_hash: String::from("4dbba1ba9fb18b0034965712598be1368edcf91ae2c551d59462aab578dab9c5"),
+                graph_account: String::from("0xa1"),
+            },
+            signature: String::from("03b197380ab9ee3a9fcaea1301224ad1ff02e9e414275fd79d6ee463b21eb6957af7670a26b0a7f8a6316d95dba8497f2bd67b32b39be07073cf81beff0b37961b"),
+        }]
     }
 }
 criterion_main!(attestation::benches);

--- a/poi-radio/src/config.rs
+++ b/poi-radio/src/config.rs
@@ -52,6 +52,8 @@ pub struct Config {
         hide_env_values = true,
         help = "Private key to the Graphcast ID wallet (Precendence over mnemonics)",
     )]
+    // should keep this value private, this is current public due to the constructing a Config in test-utils
+    // We can get around this by making an explicit function to make config instead of direct build in {}
     pub private_key: Option<String>,
     #[clap(
         long,

--- a/poi-radio/src/lib.rs
+++ b/poi-radio/src/lib.rs
@@ -1,6 +1,5 @@
 use async_graphql::{Error, ErrorExtensions, SimpleObject};
 use autometrics::autometrics;
-use chrono::Utc;
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;

--- a/poi-radio/src/lib.rs
+++ b/poi-radio/src/lib.rs
@@ -1,5 +1,6 @@
 use async_graphql::{Error, ErrorExtensions, SimpleObject};
 use autometrics::autometrics;
+use chrono::Utc;
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
@@ -14,15 +15,23 @@ use std::{
     },
 };
 use tokio::signal;
-use tracing::error;
+use tracing::{error, trace};
 
-use graphcast_sdk::{
-    graphcast_agent::GraphcastAgent, graphql::client_network::query_network_subgraph,
-    networks::NetworkName, BlockPointer,
-};
 use graphcast_sdk::{
     graphcast_agent::GraphcastAgentError,
     graphql::{client_graph_node::get_indexing_statuses, QueryError},
+};
+use graphcast_sdk::{
+    graphcast_agent::{
+        message_typing::{BuildMessageError, GraphcastMessage},
+        GraphcastAgent,
+    },
+    graphql::{
+        client_graph_node::query_graph_node_network_block_hash,
+        client_network::query_network_subgraph,
+    },
+    networks::NetworkName,
+    BlockPointer,
 };
 
 use crate::operator::attestation::AttestationError;
@@ -54,18 +63,123 @@ pub struct RadioPayloadMessage {
     pub identifier: String,
     #[prost(string, tag = "2")]
     pub content: String,
+    //TODO: see if timestamp that comes with waku message can be used
+    /// nonce cached to check against the next incoming message
+    #[prost(int64, tag = "3")]
+    pub nonce: i64,
+    /// blockchain relevant to the message
+    #[prost(string, tag = "4")]
+    pub network: String,
+    /// block relevant to the message
+    #[prost(uint64, tag = "5")]
+    pub block_number: u64,
+    /// block hash generated from the block number
+    #[prost(string, tag = "6")]
+    pub block_hash: String,
+    /// Graph account sender
+    #[prost(string, tag = "7")]
+    pub graph_account: String,
 }
 
 impl RadioPayloadMessage {
-    pub fn new(identifier: String, content: String) -> Self {
+    pub fn new(
+        identifier: String,
+        content: String,
+        nonce: i64,
+        network: String,
+        block_number: u64,
+        block_hash: String,
+        graph_account: String,
+    ) -> Self {
         RadioPayloadMessage {
             identifier,
             content,
+            nonce,
+            network,
+            block_number,
+            block_hash,
+            graph_account,
         }
+    }
+
+    pub fn build(
+        identifier: String,
+        content: String,
+        network: NetworkName,
+        block_number: u64,
+        block_hash: String,
+        graph_account: String,
+    ) -> Self {
+        RadioPayloadMessage::new(
+            identifier,
+            content,
+            Utc::now().timestamp(),
+            network.to_string(),
+            block_number,
+            block_hash,
+            graph_account,
+        )
     }
 
     pub fn payload_content(&self) -> String {
         self.content.clone()
+    }
+
+    // Check for the valid hash between local graph node and gossip
+    pub async fn valid_hash(&self, graph_node_endpoint: &str) -> Result<&Self, BuildMessageError> {
+        let block_hash: String = query_graph_node_network_block_hash(
+            graph_node_endpoint,
+            &self.network,
+            self.block_number,
+        )
+        .await
+        .map_err(BuildMessageError::FieldDerivations)?;
+
+        trace!(
+            network = tracing::field::debug(self.network.clone()),
+            block_number = self.block_number,
+            block_hash = block_hash,
+            "Queried block hash from graph node",
+        );
+
+        if self.block_hash == block_hash {
+            Ok(self)
+        } else {
+            Err(BuildMessageError::InvalidFields(anyhow::anyhow!(
+                "Message hash ({}) differ from trusted provider response ({}), drop message",
+                self.block_hash,
+                block_hash
+            )))
+        }
+    }
+
+    /// Check duplicated fields: payload message has duplicated fields with GraphcastMessage, the values must be the same
+    pub fn valid_outer(&self, outer: &GraphcastMessage<Self>) -> Result<&Self, BuildMessageError> {
+        if self.nonce == outer.nonce
+            && self.graph_account == outer.graph_account
+            && self.identifier == outer.identifier
+        {
+            Ok(self)
+        } else {
+            Err(BuildMessageError::InvalidFields(anyhow::anyhow!(
+                "Radio message wrapped by inconsistent GraphcastMessage: {:#?} <- {:#?}",
+                &self,
+                &outer,
+            )))
+        }
+    }
+
+    /// Make sure all messages stored are valid
+    pub async fn validity_check(
+        &self,
+        gc_msg: &GraphcastMessage<Self>,
+        graph_node_endpoint: &str,
+    ) -> Result<&Self, BuildMessageError> {
+        let _ = self
+            .valid_hash(graph_node_endpoint)
+            .await
+            .map(|radio_msg| radio_msg.valid_outer(gc_msg))??;
+        Ok(self)
     }
 }
 
@@ -74,9 +188,9 @@ impl RadioPayloadMessage {
 /// A vec of strings for subtopics
 pub async fn active_allocation_hashes(
     network_subgraph: &str,
-    indexer_address: String,
+    indexer_address: &str,
 ) -> Vec<String> {
-    query_network_subgraph(network_subgraph, &indexer_address)
+    query_network_subgraph(network_subgraph, indexer_address)
         .await
         .map(|result| result.indexer_allocations())
         .unwrap_or_else(|e| {
@@ -183,5 +297,51 @@ impl OperationError {
 impl ErrorExtensions for OperationError {
     fn extend(&self) -> Error {
         Error::new(format!("{}", self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn simple_message() -> RadioPayloadMessage {
+        RadioPayloadMessage::new(
+            String::from("QmHash"),
+            String::from("0x0"),
+            1,
+            String::from("goerli"),
+            0,
+            String::from("0xa"),
+            String::from("0xaaa"),
+        )
+    }
+
+    fn wrong_outer_message(payload: RadioPayloadMessage) -> GraphcastMessage<RadioPayloadMessage> {
+        GraphcastMessage {
+            identifier: String::from("ping-pong-content-topic"),
+            payload,
+            nonce: 1687448729,
+            graph_account: String::from("0xe9a1cabd57700b17945fd81feefba82340d9568f"),
+            signature: String::from("2cd3fa305efd9c362bc71adee6e5a85c357a951af84c80667b8ddae23ac81c3821dac7d9c167e2776a9a56d8726b472312f40d9cc7461d1a6950d00e52d6e8521b")
+        }
+    }
+
+    fn good_outer_message(payload: RadioPayloadMessage) -> GraphcastMessage<RadioPayloadMessage> {
+        GraphcastMessage {
+            identifier: payload.identifier.clone(),
+            payload: payload.clone(),
+            nonce: payload.nonce,
+            graph_account: payload.graph_account,
+            signature: String::from("2cd3fa305efd9c362bc71adee6e5a85c357a951af84c80667b8ddae23ac81c3821dac7d9c167e2776a9a56d8726b472312f40d9cc7461d1a6950d00e52d6e8521b")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_message_wrap() {
+        let wrong_msg = wrong_outer_message(simple_message());
+        let right_msg = good_outer_message(simple_message());
+
+        assert!(simple_message().valid_outer(&wrong_msg).is_err());
+        assert!(simple_message().valid_outer(&right_msg).is_ok());
     }
 }

--- a/poi-radio/src/lib.rs
+++ b/poi-radio/src/lib.rs
@@ -105,6 +105,7 @@ impl RadioPayloadMessage {
     pub fn build(
         identifier: String,
         content: String,
+        nonce: i64,
         network: NetworkName,
         block_number: u64,
         block_hash: String,
@@ -113,7 +114,7 @@ impl RadioPayloadMessage {
         RadioPayloadMessage::new(
             identifier,
             content,
-            Utc::now().timestamp(),
+            nonce,
             network.to_string(),
             block_number,
             block_hash,

--- a/poi-radio/src/lib.rs
+++ b/poi-radio/src/lib.rs
@@ -155,16 +155,20 @@ impl RadioPayloadMessage {
 
     /// Check duplicated fields: payload message has duplicated fields with GraphcastMessage, the values must be the same
     pub fn valid_outer(&self, outer: &GraphcastMessage<Self>) -> Result<&Self, BuildMessageError> {
-        if self.nonce == outer.nonce
-            && self.graph_account == outer.graph_account
-            && self.identifier == outer.identifier
-        {
+        let nonce_check = self.nonce == outer.nonce;
+        let account_check = self.graph_account == outer.graph_account;
+        let identifier_check = self.identifier == outer.identifier;
+
+        if nonce_check && account_check && identifier_check {
             Ok(self)
         } else {
             Err(BuildMessageError::InvalidFields(anyhow::anyhow!(
-                "Radio message wrapped by inconsistent GraphcastMessage: {:#?} <- {:#?}",
+                "Radio message wrapped by inconsistent GraphcastMessage: {:#?} <- {:#?}\nNonce check: {:#?}\nAccount check: {:#?}\nIdentifier check: {:#?}",
                 &self,
                 &outer,
+                nonce_check,
+                account_check,
+                identifier_check
             )))
         }
     }

--- a/poi-radio/src/operator/operation.rs
+++ b/poi-radio/src/operator/operation.rs
@@ -156,7 +156,10 @@ pub async fn message_send(
                 block_hash,
                 graphcast_agent.graphcast_identity.graph_account.clone(),
             );
-            match graphcast_agent.send_message(&id, radio_message, nonce).await {
+            match graphcast_agent
+                .send_message(&id, radio_message, nonce)
+                .await
+            {
                 Ok(msg_id) => {
                     save_local_attestation(
                         local_attestations.clone(),
@@ -494,12 +497,12 @@ impl RadioOperator {
                     //         .clean_local_attestations(b, d.clone());
                     //     self.persisted_state
                     //         .clean_remote_messages(b, d.clone());
-                        
+
                     //     compare_ops.push(Err(OperationError::CompareTrigger(d, b, m).clone_with_inner()));
                     // }
                     Err(e) => {
                         trace!(err = tracing::field::debug(&e), "Compare handles");
-                        
+
                         compare_ops.push(Err(e.clone_with_inner()));
                     }
                 }

--- a/poi-radio/src/server/model/mod.rs
+++ b/poi-radio/src/server/model/mod.rs
@@ -1,6 +1,5 @@
 use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject};
 use chrono::Utc;
-
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
@@ -284,13 +283,12 @@ impl POIRadioContext {
             let locals = attestations_to_vec(&self.local_attestations(identifier.clone(), block));
 
             let config = self.radio_config();
-            let network_subgraph = config.network_subgraph.clone();
 
             let mut res = vec![];
             for entry in locals {
                 let deployment_identifier = entry.deployment.clone();
                 let msgs = self.remote_messages_filtered(&identifier, &block);
-                let remote_attestations = process_messages(msgs, &network_subgraph)
+                let remote_attestations = process_messages(msgs, &config.callbook())
                     .await
                     .ok()
                     .and_then(|r| {
@@ -327,7 +325,7 @@ fn filter_remote_messages(
         None => true, // Skip check
     };
     let is_matching_block = match block {
-        Some(b) => entry.block_number == *b,
+        Some(b) => entry.payload.block_number == *b,
         None => true, // Skip check
     };
     is_matching_identifier && is_matching_block

--- a/poi-radio/src/state.rs
+++ b/poi-radio/src/state.rs
@@ -153,11 +153,12 @@ impl PersistedState {
         let mut valid_messages = vec![];
 
         for message in remote_messages {
-            let is_valid = tokio::runtime::Runtime::new().unwrap().block_on(
+            let is_valid = 
                 message
                     .payload
-                    .validity_check(&message, graph_node_endpoint),
-            );
+                    .validity_check(&message, graph_node_endpoint)
+                    .await
+            ;
 
             if is_valid.is_ok() {
                 valid_messages.push(message);
@@ -365,6 +366,7 @@ mod tests {
         let radio_msg = RadioPayloadMessage::build(
             hash.clone(),
             content,
+            nonce,
             NetworkName::Goerli,
             block_number,
             block_hash,

--- a/poi-radio/src/state.rs
+++ b/poi-radio/src/state.rs
@@ -125,16 +125,6 @@ impl PersistedState {
         self.remote_messages.lock().unwrap().push(msg)
     }
 
-    /// Update comparison_results
-    pub fn update_comparison_result(&self, comparison_result: ComparisonResult) {
-        let deployment = comparison_result.clone().deployment;
-
-        self.comparison_results
-            .lock()
-            .unwrap()
-            .insert(deployment, comparison_result);
-    }
-
     /// Add entry to comparison_results
     pub fn add_comparison_result(&self, comparison_result: ComparisonResult) {
         let deployment = comparison_result.clone().deployment;
@@ -302,7 +292,6 @@ impl PersistedState {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use graphcast_sdk::networks::NetworkName;
 
     use crate::operator::attestation::{save_local_attestation, ComparisonResultType};

--- a/poi-radio/src/state.rs
+++ b/poi-radio/src/state.rs
@@ -95,6 +95,15 @@ impl PersistedState {
         self.comparison_results.lock().unwrap().clone()
     }
 
+    /// Getter for comparison result
+    pub fn comparison_result(&self, deployment: String) -> Option<ComparisonResult> {
+        self.comparison_results
+            .lock()
+            .unwrap()
+            .get(&deployment)
+            .cloned()
+    }
+
     /// Update local_attestations
     pub async fn update_local(&mut self, local_attestations: Local) {
         self.local_attestations = local_attestations;

--- a/poi-radio/src/state.rs
+++ b/poi-radio/src/state.rs
@@ -153,12 +153,10 @@ impl PersistedState {
         let mut valid_messages = vec![];
 
         for message in remote_messages {
-            let is_valid = 
-                message
-                    .payload
-                    .validity_check(&message, graph_node_endpoint)
-                    .await
-            ;
+            let is_valid = message
+                .payload
+                .validity_check(&message, graph_node_endpoint)
+                .await;
 
             if is_valid.is_ok() {
                 valid_messages.push(message);

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
 test-utils = { path = "../test-utils" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
 test-utils = { path = "../test-utils" }
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
 test-utils = { path = "../test-utils" }
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-runner/src/message_handling.rs
+++ b/test-runner/src/message_handling.rs
@@ -81,10 +81,7 @@ pub async fn send_and_receive_test() {
     for (index, message1) in remote_messages.iter().enumerate() {
         for message2 in remote_messages.iter().skip(index + 1) {
             if messages_are_equal(message1, message2)
-                && payloads_are_equal(
-                    message1.payload.as_ref().unwrap(),
-                    message2.payload.as_ref().unwrap(),
-                )
+                && payloads_are_equal(&message1.payload, &message2.payload)
             {
                 panic!(
                     "Duplicate remote message found with identifier {}",

--- a/test-runner/src/poi_divergent.rs
+++ b/test-runner/src/poi_divergent.rs
@@ -31,7 +31,7 @@ pub async fn poi_divergent_test() {
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
 
-    sleep(Duration::from_secs(300)).await;
+    sleep(Duration::from_secs(550)).await;
 
     let persisted_state = PersistedState::load_cache(&store_path);
     debug!("persisted state {:?}", persisted_state);

--- a/test-runner/src/poi_match.rs
+++ b/test-runner/src/poi_match.rs
@@ -31,7 +31,7 @@ pub async fn poi_match_test() {
 
     let process_manager = setup(&config, test_file_name, &mut test_sender_config).await;
 
-    sleep(Duration::from_secs(300)).await;
+    sleep(Duration::from_secs(550)).await;
 
     let persisted_state = PersistedState::load_cache(&store_path);
     debug!("persisted state {:?}", persisted_state);

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 test-utils = { path = "../test-utils" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
 test-utils = { path = "../test-utils" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
 test-utils = { path = "../test-utils" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }

--- a/test-sender/src/main.rs
+++ b/test-sender/src/main.rs
@@ -81,30 +81,30 @@ async fn start_sender(config: TestSenderConfig) {
             let content_topic = format!("/{}/0/{}/proto", config.radio_name, topic);
             let content_topic = WakuContentTopic::from_str(&content_topic).unwrap();
 
+            let nonce = config.nonce.clone().unwrap().parse::<i64>().unwrap();
+
             let radio_payload_clone = config.radio_payload.clone();
             match radio_payload_clone.as_deref() {
                 Some("radio_payload_message") => {
                     let radio_payload = RadioPayloadMessage::build(
                         topic.clone(),
                         config.poi.clone().unwrap(),
-                        timestamp,
+                        nonce,
                         NetworkName::Goerli,
                         timestamp.try_into().unwrap(),
                         config.block_hash.clone().unwrap(),
                         "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
                     );
 
-                    let mut graphcast_message = GraphcastMessage::build(
+                    let graphcast_message = GraphcastMessage::build(
                         &wallet,
                         topic.clone(),
-                        timestamp,
+                        nonce,
                         "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
                         radio_payload,
                     )
                     .await
                     .unwrap();
-
-                    graphcast_message.nonce = config.nonce.clone().unwrap().parse::<i64>().unwrap();
 
                     match graphcast_message.send_to_waku(
                         &node_handle,
@@ -124,7 +124,7 @@ async fn start_sender(config: TestSenderConfig) {
                     let graphcast_message = GraphcastMessage::build(
                         &wallet,
                         topic.clone(),
-                        timestamp,
+                        nonce,
                         "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
                         payload,
                     )

--- a/test-sender/src/main.rs
+++ b/test-sender/src/main.rs
@@ -84,17 +84,20 @@ async fn start_sender(config: TestSenderConfig) {
             let radio_payload_clone = config.radio_payload.clone();
             match radio_payload_clone.as_deref() {
                 Some("radio_payload_message") => {
-                    let radio_payload =
-                        RadioPayloadMessage::new(topic.clone(), config.poi.clone().unwrap());
-
-                    let mut graphcast_message = GraphcastMessage::build(
-                        &wallet,
+                    let radio_payload = RadioPayloadMessage::build(
                         topic.clone(),
-                        Some(radio_payload),
+                        config.poi.clone().unwrap(),
                         NetworkName::Goerli,
                         timestamp.try_into().unwrap(),
                         config.block_hash.clone().unwrap(),
                         "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
+                    );
+
+                    let mut graphcast_message = GraphcastMessage::build(
+                        &wallet,
+                        topic.clone(),
+                        "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
+                        radio_payload,
                     )
                     .await
                     .unwrap();
@@ -119,11 +122,8 @@ async fn start_sender(config: TestSenderConfig) {
                     let graphcast_message = GraphcastMessage::build(
                         &wallet,
                         topic.clone(),
-                        Some(payload),
-                        NetworkName::Goerli,
-                        timestamp.try_into().unwrap(),
-                        config.block_hash.clone().unwrap(),
                         "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
+                        payload,
                     )
                     .await
                     .unwrap();

--- a/test-sender/src/main.rs
+++ b/test-sender/src/main.rs
@@ -87,6 +87,7 @@ async fn start_sender(config: TestSenderConfig) {
                     let radio_payload = RadioPayloadMessage::build(
                         topic.clone(),
                         config.poi.clone().unwrap(),
+                        timestamp,
                         NetworkName::Goerli,
                         timestamp.try_into().unwrap(),
                         config.block_hash.clone().unwrap(),
@@ -96,6 +97,7 @@ async fn start_sender(config: TestSenderConfig) {
                     let mut graphcast_message = GraphcastMessage::build(
                         &wallet,
                         topic.clone(),
+                        timestamp,
                         "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
                         radio_payload,
                     )
@@ -122,6 +124,7 @@ async fn start_sender(config: TestSenderConfig) {
                     let graphcast_message = GraphcastMessage::build(
                         &wallet,
                         topic.clone(),
+                        timestamp,
                         "0x7e6528e4ce3055e829a32b5dc4450072bac28bc6".to_string(),
                         payload,
                     )

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "hope/msg-restructure" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 
 [dependencies]
 waku = { version = "0.1.1", package = "waku-bindings" }
-graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev = "7b4be3b" }
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 poi-radio = { path = "../poi-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }
 tracing = "0.1"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -273,12 +273,13 @@ where
 {
     msg1.identifier == msg2.identifier
         && msg1.nonce == msg2.nonce
-        && msg1.network == msg2.network
-        && msg1.block_number == msg2.block_number
-        && msg1.block_hash == msg2.block_hash
         && msg1.signature == msg2.signature
 }
 
 pub fn payloads_are_equal(payload1: &RadioPayloadMessage, payload2: &RadioPayloadMessage) -> bool {
-    payload1.identifier == payload2.identifier && payload1.content == payload2.content
+    payload1.identifier == payload2.identifier
+        && payload1.content == payload2.content
+        && payload1.network == payload2.network
+        && payload1.block_number == payload2.block_number
+        && payload1.block_hash == payload2.block_hash
 }


### PR DESCRIPTION
### Description

Add server context functions to server `comparison_results` and `comparison_result`, avoid processing messages again if only grab the latest result

### Issue link (if applicable)

Resolve #197

### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
